### PR TITLE
removed hardcoded tmp from cabal sandbox path.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ function build_shared_binary {
     return
   fi
 
-  dir=`mktemp -d /$TMPDIR/build-XXXX`
+  dir=`mktemp -d /${TMPDIR:-/tmp}/build-XXXX`
 
   msg "Building $pkg (in $dir)"
   cd $dir


### PR DESCRIPTION
this patch is necessary to support systems whose tmp directory is mounted noexec.
