### PR TITLE
Update vim-commentary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ selections to it. This works well for evaluating things in GHCI.
 <table>
 <tbody>
   <tr>
-    <td>\\</td><td>Comment / Uncomment selection</td>
+    <td>gc</td><td>Comment / Uncomment selection</td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
`\\` gives the error `\\ is deprecated. Use gc` in the latest version of [vim-commentary](http://github.com/tpope/vim-commentary).
