### PR TITLE
`Bundle` is deprecated in Vundle

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -42,53 +42,58 @@ nnoremap Q <nop>
 
 set nocompatible
 filetype off
-set rtp+=~/.vim/bundle/vundle/
-call vundle#rc()
+set rtp+=~/.vim/bundle/Vundle.vim
+call vundle#begin()
 
 " let Vundle manage Vundle
 " required!
-Bundle 'gmarik/vundle'
+Plugin 'gmarik/Vundle.vim'
 
 " Support bundles
-Bundle 'jgdavey/tslime.vim'
-Bundle 'Shougo/vimproc.vim'
-Bundle 'ervandew/supertab'
-Bundle 'scrooloose/syntastic'
-Bundle 'moll/vim-bbye'
-Bundle 'nathanaelkane/vim-indent-guides'
-Bundle 'vim-scripts/gitignore'
+Plugin 'jgdavey/tslime.vim'
+Plugin 'Shougo/vimproc.vim'
+Plugin 'ervandew/supertab'
+Plugin 'scrooloose/syntastic'
+Plugin 'moll/vim-bbye'
+Plugin 'nathanaelkane/vim-indent-guides'
+Plugin 'vim-scripts/gitignore'
 
 " Git
-Bundle 'tpope/vim-fugitive'
-Bundle 'int3/vim-extradite'
+Plugin 'tpope/vim-fugitive'
+Plugin 'int3/vim-extradite'
 
 " Bars, panels, and files
-Bundle 'scrooloose/nerdtree'
-Bundle 'bling/vim-airline'
-Bundle 'kien/ctrlp.vim'
-Bundle 'majutsushi/tagbar'
+Plugin 'scrooloose/nerdtree'
+Plugin 'bling/vim-airline'
+Plugin 'kien/ctrlp.vim'
+Plugin 'majutsushi/tagbar'
 
 " Text manipulation
-Bundle 'vim-scripts/Align'
-Bundle 'vim-scripts/Gundo'
-Bundle 'tpope/vim-commentary'
-Bundle 'godlygeek/tabular'
-Bundle 'michaeljsmith/vim-indent-object'
+Plugin 'vim-scripts/Align'
+Plugin 'vim-scripts/Gundo'
+Plugin 'tpope/vim-commentary'
+Plugin 'godlygeek/tabular'
+Plugin 'michaeljsmith/vim-indent-object'
 
 " Allow pane movement to jump out of vim into tmux
-Bundle 'christoomey/vim-tmux-navigator'
+Plugin 'christoomey/vim-tmux-navigator'
 
 " Haskell
-Bundle 'raichoo/haskell-vim'
-Bundle 'enomsg/vim-haskellConcealPlus'
-Bundle 'eagletmt/ghcmod-vim'
-Bundle 'eagletmt/neco-ghc'
-Bundle 'Twinside/vim-hoogle'
+Plugin 'raichoo/haskell-vim'
+Plugin 'enomsg/vim-haskellConcealPlus'
+Plugin 'eagletmt/ghcmod-vim'
+Plugin 'eagletmt/neco-ghc'
+Plugin 'Twinside/vim-hoogle'
+
+" Colorscheme
+Plugin 'vim-scripts/wombat256.vim'
 
 " Custom bundles
 if filereadable(expand("~/.vim.local/bundles.vim"))
   source ~/.vim.local/bundles.vim
 endif
+
+call vundle#end()
 
 " }}}
 
@@ -169,7 +174,6 @@ set mouse=a
 
 " Colors and Fonts {{{
 
-Bundle 'vim-scripts/wombat256.vim'
 try
   colorscheme wombat256mod
 catch

--- a/install.sh
+++ b/install.sh
@@ -67,13 +67,13 @@ if [ ! -d $endpath/.vim/bundle ]; then
 fi
 ln -sf $endpath/.vim $HOME/.vim
 
-if [ ! -e $HOME/.vim/bundle/vundle ]; then
+if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
   msg "Installing Vundle"
-  git clone http://github.com/gmarik/vundle.git $HOME/.vim/bundle/vundle
+  git clone https://github.com/gmarik/Vundle.vim.git $HOME/.vim/bundle/Vundle.vim
 fi
 
 msg "Installing plugins using Vundle..."
-vim -T dumb -E -u $endpath/.vimrc +BundleInstall! +BundleClean! +qall
+vim -T dumb -E -u $endpath/.vimrc +PluginInstall! +PluginClean! +qall
 
 msg "Building vimproc.vim"
 make -C ~/.vim/bundle/vimproc.vim


### PR DESCRIPTION
There are some changes being made to Vundle recently:
* The repo is renamed from _gmarik/vundle_ to _gmarik/Vundle.vim_.
* We should use the ``vundle#begin()`` / ``vundle#end()`` block in place of ``vundle#rc()``.
* _Bundle_ should be renamed to _Plugin_.

Kindly refer to [here](https://github.com/gmarik/Vundle.vim/commit/0521de95eac09298c4e71b3662839612280c1ae9), [here](https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396) and [here](https://github.com/gmarik/Vundle.vim/issues/413) for more information. 