### PR TITLE
ingore files under .cabal-sandbox when using fuzzy file find

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -256,7 +256,7 @@ nmap <silent> <leader>u :GundoToggle<CR>
 nnoremap <silent> <Leader><space> :CtrlP<CR>
 let g:ctrlp_max_files=0
 let g:ctrlp_show_hidden=1
-let g:ctrlp_custom_ignore = { 'dir': '\v[\/](.git)$' }
+let g:ctrlp_custom_ignore = { 'dir': '\v[\/](.git|.cabal-sandbox)$' }
 
 " }}}
 


### PR DESCRIPTION
When using sandbox inside a project, lots of files are generated under .cabal-sandbox. This increases dramatically the loading time when using fuzzy file find. Therefore I suggest ignore this folder in fuzzy file find plugin.