### PR TITLE
No space between -i and its argument.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ msg "Building vimproc.vim"
 make -C ~/.vim/bundle/vimproc.vim
 
 msg "Adding extra stack deps if needed"
-sed -i .bak 's/extra-deps: \[\]/extra-deps: [cabal-helper-0.6.1.0, pure-cdb-0.1.1]/' ~/.stack/global/stack.yaml
+sed -i.bak 's/extra-deps: \[\]/extra-deps: [cabal-helper-0.6.1.0, pure-cdb-0.1.1]/' ~/.stack/global/stack.yaml
 
 msg "Installing helper binaries"
 stack --resolver nightly install ghc-mod hasktags codex hscope pointfree pointful hoogle stylish-haskell


### PR DESCRIPTION
sed: -e expression #1, char 1: unknown command: `.'