### PR TITLE
Use pushd/popd instead of cd

### DIFF
--- a/git-hscope
+++ b/git-hscope
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-pushd $(git rev-parse --show-toplevel) &>/dev/null
+pushd $(git rev-parse --show-toplevel) >/dev/null
 git ls-files | grep '\.l\?hs$' | xargs hscope -b "$@"
-popd &>/dev/null
+popd >/dev/null

--- a/git-hscope
+++ b/git-hscope
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-cd $(git rev-parse --show-toplevel)
+pushd $(git rev-parse --show-toplevel) &>/dev/null
 git ls-files | grep '\.l\?hs$' | xargs hscope -b "$@"
-cd -
+popd &>/dev/null


### PR DESCRIPTION
Not strictly necessary, but using `pushd` and `popd` should be a bit more stable than plain old `cd`.