### PR TITLE
Completely replace Vundle with vim-plug

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -47,7 +47,6 @@ nnoremap Q <nop>
 " vim-plug {{{
 
 set nocompatible
-filetype off
 
 call plug#begin('~/.vim/bundle')
 
@@ -184,9 +183,6 @@ try
 catch
 endtry
 
-" Enable syntax highlighting
-syntax enable
-
 " Adjust signscolumn and syntastic to match wombat
 hi! link SignColumn LineNr
 hi! link SyntasticErrorSign ErrorMsg
@@ -195,10 +191,6 @@ hi! link SyntasticWarningSign WarningMsg
 " Use pleasant but very visible search hilighting
 hi Search ctermfg=white ctermbg=173 cterm=none guifg=#ffffff guibg=#e5786d gui=none
 hi! link Visual Search
-
-" Enable filetype plugins
-filetype plugin on
-filetype indent on
 
 " Match wombat colors in nerd tree
 hi Directory guifg=#8ac6f2

--- a/.vimrc
+++ b/.vimrc
@@ -82,12 +82,12 @@ Plug 'easymotion/vim-easymotion'
 Plug 'christoomey/vim-tmux-navigator'
 
 " Haskell
-Plug 'neovimhaskell/haskell-vim'
-Plug 'enomsg/vim-haskellConcealPlus'
-Plug 'eagletmt/ghcmod-vim'
-Plug 'bitc/vim-hdevtools'
-Plug 'eagletmt/neco-ghc'
-Plug 'Twinside/vim-hoogle'
+Plug 'neovimhaskell/haskell-vim', { 'for': 'haskell' }
+Plug 'enomsg/vim-haskellConcealPlus', { 'for': 'haskell' }
+Plug 'eagletmt/ghcmod-vim', { 'for': 'haskell' }
+Plug 'bitc/vim-hdevtools', { 'for': 'haskell' }
+Plug 'eagletmt/neco-ghc', { 'for': 'haskell' }
+Plug 'Twinside/vim-hoogle', { 'for': 'haskell' }
 
 " Colorscheme
 Plug 'vim-scripts/wombat256.vim'

--- a/.vimrc
+++ b/.vimrc
@@ -44,64 +44,61 @@ nnoremap Q <nop>
 
 " }}}
 
-" Vundle {{{
+" vim-plug {{{
 
 set nocompatible
 filetype off
-set rtp+=~/.vim/bundle/Vundle.vim
-call vundle#begin()
 
-" let Vundle manage Vundle
-" required!
-Plugin 'gmarik/Vundle.vim'
+call plug#begin('~/.vim/bundle')
 
 " Support bundles
-Plugin 'jgdavey/tslime.vim'
-Plugin 'Shougo/vimproc.vim'
-Plugin 'ervandew/supertab'
-Plugin 'scrooloose/syntastic'
-Plugin 'moll/vim-bbye'
-Plugin 'nathanaelkane/vim-indent-guides'
-Plugin 'vim-scripts/gitignore'
+Plug 'jgdavey/tslime.vim'
+Plug 'Shougo/vimproc.vim', { 'do': 'make' }
+Plug 'ervandew/supertab'
+Plug 'scrooloose/syntastic'
+Plug 'moll/vim-bbye'
+Plug 'nathanaelkane/vim-indent-guides'
+Plug 'vim-scripts/gitignore'
 
 " Git
-Plugin 'tpope/vim-fugitive'
-Plugin 'int3/vim-extradite'
+Plug 'tpope/vim-fugitive'
+Plug 'int3/vim-extradite'
 
 " Bars, panels, and files
-Plugin 'scrooloose/nerdtree'
-Plugin 'bling/vim-airline'
-Plugin 'ctrlpvim/ctrlp.vim'
-Plugin 'majutsushi/tagbar'
+Plug 'scrooloose/nerdtree'
+Plug 'bling/vim-airline'
+Plug 'ctrlpvim/ctrlp.vim'
+Plug 'majutsushi/tagbar'
 
 " Text manipulation
-Plugin 'vim-scripts/Align'
-Plugin 'simnalamburt/vim-mundo'
-Plugin 'tpope/vim-commentary'
-Plugin 'godlygeek/tabular'
-Plugin 'michaeljsmith/vim-indent-object'
-Plugin 'easymotion/vim-easymotion'
+Plug 'vim-scripts/Align'
+Plug 'simnalamburt/vim-mundo'
+Plug 'tpope/vim-commentary'
+Plug 'godlygeek/tabular'
+Plug 'michaeljsmith/vim-indent-object'
+Plug 'easymotion/vim-easymotion'
 
 " Allow pane movement to jump out of vim into tmux
-Plugin 'christoomey/vim-tmux-navigator'
+Plug 'christoomey/vim-tmux-navigator'
 
 " Haskell
-Plugin 'neovimhaskell/haskell-vim'
-Plugin 'enomsg/vim-haskellConcealPlus'
-Plugin 'eagletmt/ghcmod-vim'
-Plugin 'bitc/vim-hdevtools'
-Plugin 'eagletmt/neco-ghc'
-Plugin 'Twinside/vim-hoogle'
+Plug 'neovimhaskell/haskell-vim'
+Plug 'enomsg/vim-haskellConcealPlus'
+Plug 'eagletmt/ghcmod-vim'
+Plug 'bitc/vim-hdevtools'
+Plug 'eagletmt/neco-ghc'
+Plug 'Twinside/vim-hoogle'
 
 " Colorscheme
-Plugin 'vim-scripts/wombat256.vim'
+Plug 'vim-scripts/wombat256.vim'
 
 " Custom bundles
-if filereadable(expand("~/.vim.local/bundles.vim"))
-  source ~/.vim.local/bundles.vim
+" Make it incompatible with prev versions using different file
+if filereadable(expand("~/.vim.local/plugins.vim"))
+  source ~/.vim.local/plugins.vim
 endif
 
-call vundle#end()
+call plug#end()
 
 " }}}
 

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,20 @@ if ! verlte '7.4' $VIM_VER ; then
   exit 1
 fi
 
+msg "Testing for broken Ruby interface in vim"
+vim -T dumb --cmd "ruby puts RUBY_VERSION" --cmd qa!
+if [ $? -ne 0 ] ; then
+  msg "The Ruby interface is broken on your installation of vim."
+  msg "Reinstall or recompile vim."
+  msg ""
+  msg "If you're on OS X, try the following:"
+  detail "rvm use system"
+  detail "brew reinstall vim"
+  msg ""
+  msg "If nothing helped, please report at https://github.com/begriffs/haskell-vim-now/issues/new"
+  exit 1
+fi
+
 endpath="$HOME/.haskell-vim-now"
 
 if [ ! -e $endpath/.git ]; then

--- a/install.sh
+++ b/install.sh
@@ -82,16 +82,14 @@ if [ ! -d $endpath/.vim/bundle ]; then
 fi
 ln -sf $endpath/.vim $HOME/.vim
 
-if [ ! -e $HOME/.vim/bundle/Vundle.vim ]; then
-  msg "Installing Vundle"
-  git clone https://github.com/gmarik/Vundle.vim.git $HOME/.vim/bundle/Vundle.vim
+if [ ! -e $HOME/.vim/autoload/plug.vim ]; then
+  msg "Installing vim-plug"
+  curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
 
-msg "Installing plugins using Vundle..."
-vim -T dumb -E -u $endpath/.vimrc +PluginInstall! +PluginClean! +qall
-
-msg "Building vimproc.vim"
-make -C ~/.vim/bundle/vimproc.vim
+msg "Installing plugins using vim-plug..."
+vim -T dumb -E -u $endpath/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
 
 msg "Setting up GHC if needed"
 stack setup


### PR DESCRIPTION
Related to #81
It's necessary to change all *Plugin* to *Plug* in *bundles.vim*, so I decided to (temporary at least) change source from *bundles.vim* to *plug.vim* to avoid errors.
It can be done automatically via **install.sh** or manually by user (preferred, I think).