### PR TITLE
Switch to maintained fork of ctrlp.vim

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -71,7 +71,7 @@ Plugin 'int3/vim-extradite'
 " Bars, panels, and files
 Plugin 'scrooloose/nerdtree'
 Plugin 'bling/vim-airline'
-Plugin 'kien/ctrlp.vim'
+Plugin 'ctrlpvim/ctrlp.vim'
 Plugin 'majutsushi/tagbar'
 
 " Text manipulation


### PR DESCRIPTION
kien/ctrlp.vim is unmaintained and ctrplvim/ctrlp.vim should be used instead.
See kien/ctrlp.vim#669.