### PR TITLE
Use vim-mundo instead of Gundo

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -76,7 +76,7 @@ Plugin 'majutsushi/tagbar'
 
 " Text manipulation
 Plugin 'vim-scripts/Align'
-Plugin 'vim-scripts/Gundo'
+Plugin 'simnalamburt/vim-mundo'
 Plugin 'tpope/vim-commentary'
 Plugin 'godlygeek/tabular'
 Plugin 'michaeljsmith/vim-indent-object'


### PR DESCRIPTION
Latest commit to sjl/Gundo dates on 11 Jul 2013. Author is not maintaining this project since then.
https://github.com/simnalamburt/vim-mundo is a fork of Gundo with fixes and a few new features (see https://github.com/simnalamburt/vim-mundo#whats-the-difference).

Besides, vim-mundo has NeoVim support (tested here, all good).