### PR TITLE
Do not use YUM if DNF found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,9 +29,10 @@ command -v dnf >/dev/null
 if [ $? -eq 0 ] ; then
   msg "dnf detected"
   sudo dnf install -y git make vim ctags libcurl-devel zlib-devel
+  DNF=1
 fi
 command -v yum >/dev/null
-if [ $? -eq 0 ] ; then
+if [ $? -eq 0 ] && [ $DNF -ne 1 ] ; then
   msg "yum detected"
   sudo yum install -y git make vim ctags libcurl-devel zlib-devel
 fi


### PR DESCRIPTION
Quick fix for Fedora Workstations with DNF, where Yum is installed too for compatibility.
Yum is mapped to DNF anyway, so there's no reason to repeat ourselves here.