### PR TITLE
Move haskell-vim-now config files to $XDG_CONFIG_HOME/haskell-vim-now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vim
-local
+*.local
+*.local.*
 backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vim
+*.vim
 *.local
 *.local.*
 backup

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .vim
+local
+backup

--- a/.vimrc
+++ b/.vimrc
@@ -7,6 +7,12 @@ else
   let local_config_dir = $HOME . "/.config/haskell-vim-now"
 endif
 
+" Precustomization
+let local_config_pre = expand(resolve(local_config_dir . "/vimrc.local.pre"))
+if filereadable(local_config_pre)
+  execute 'source '. local_config_pre
+endif
+
 " Use indentation for folds
 set foldmethod=indent
 set foldnestmax=5

--- a/.vimrc
+++ b/.vimrc
@@ -1,6 +1,13 @@
 " General {{{
 
-" use indentation for folds
+" Set XDG_CONFIG_HOME/haskell-vim-now to load user's config files
+if exists($XDG_CONFIG_HOME)
+  let local_config_dir = $XDG_CONFIG_HOME . "/haskell-vim-now"
+else
+  let local_config_dir = $HOME . "/.config/haskell-vim-now"
+endif
+
+" Use indentation for folds
 set foldmethod=indent
 set foldnestmax=5
 set foldlevelstart=99
@@ -93,8 +100,9 @@ Plug 'vim-scripts/wombat256.vim'
 
 " Custom bundles
 " Make it incompatible with prev versions using different file
-if filereadable(expand("~/.vim.local/plugins.vim"))
-  source ~/.vim.local/plugins.vim
+let user_plugins = expand(resolve(local_config_dir . "/plugins.local"))
+if filereadable(user_plugins)
+  execute 'source '. user_plugins
 endif
 
 call plug#end()
@@ -651,9 +659,9 @@ vnoremap <silent> <leader>h> :call Pointful()<CR>
 " }}}
 
 " Customization {{{
-
-if filereadable(expand("~/.vimrc.local"))
-  source ~/.vimrc.local
+let local_config_post = expand(resolve(local_config_dir . "/vimrc.local"))
+if filereadable(local_config_post)
+  execute 'source '. local_config_post
 endif
 
 " }}}

--- a/.vimrc
+++ b/.vimrc
@@ -106,7 +106,7 @@ Plug 'vim-scripts/wombat256.vim'
 
 " Custom bundles
 " Make it incompatible with prev versions using different file
-let user_plugins = expand(resolve(local_config_dir . "/plugins.local"))
+let user_plugins = expand(resolve(local_config_dir . "/plugins.vim"))
 if filereadable(user_plugins)
   execute 'source '. user_plugins
 endif

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 In less than **ten minutes** your Vim will transform into a beautiful
 Haskell paradise.  (Don't worry, it backs up your original
-configuration to `~/.vimrc.yearmonthdate_time`.) It also builds all necessary support binaries
+configuration to `~/.config/haskell-vim-now/backup/.vimrc.yearmonthdate_time`.) It also builds all necessary support binaries
 including `codex`, `hscope`, `hdevtools`, `hasktags`, `hoogle` and more.
 
 No more wading through plugins trying to make them all work together.
@@ -297,21 +297,21 @@ selections to it. This works well for evaluating things in GHCI.
 </table>
 
 (If you prefer to restore the default screen redraw action of `C-l`
-then add `unmap <c-l>` to your .vimrc.local)
+then add `unmap <c-l>` to your vimrc.local)
 
 ## Customizing
 
 After installing this configuration, your `.vimrc` and `.vim` will
 be under version control. Don't alter these files. Instead, add your
-own settings to `~/.vimrc.local` and `~/.vim.local/bundles.vim`.
+own settings to `~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local`  and `~/.config/haskell-vim-now/plugins.local`.
 
-## Adding Custom Bundles
+## Adding Custom Plugs
 
-Vundle requires all Bundle statements to be given at once. To accommodate
-this restriction, `.vimrc` sources `~/.vim.local/bundles.vim` immediately
-after its own Bundle statements.
+vim-plug requires all Plug statements to be given at once. To accommodate
+this restriction, `.vimrc` sources `~/.config/haskell-vim-now/plugins.local` immediately
+after its own Plug statements.
 
-Bundle statements made elsewhere are not recognized.
+Plug statements made elsewhere are not recognized.
 
 ### Docker image
 
@@ -334,3 +334,4 @@ However, some things (for example the hoogle database) use absolute paths and do
 
 See this [wiki](https://github.com/begriffs/haskell-vim-now/wiki/Installation-Troubleshooting)
 page for tips on fixing installation problems.
+

--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ then add `unmap <c-l>` to your vimrc.local)
 
 After installing this configuration, your `.vimrc` and `.vim` will
 be under version control. Don't alter these files. Instead, add your
-own settings to `~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local`  and `~/.config/haskell-vim-now/plugins.local`.
+own settings to `~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local`  and `~/.config/haskell-vim-now/plugins.vim`.
 
 ## Adding Custom Plugs
 
 vim-plug requires all Plug statements to be given at once. To accommodate
-this restriction, `.vimrc` sources `~/.config/haskell-vim-now/plugins.local` immediately
+this restriction, `.vimrc` sources `~/.config/haskell-vim-now/plugins.vim` immediately
 after its own Plug statements.
 
 Plug statements made elsewhere are not recognized.

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ if [ -e $HOME/.haskell-vim-now ]; then
   mv -f $HOME/.vimrc.local $DESTINATION/vimrc.local
   mv -f $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
   sed -i.bak "s/Plugin '/Plug '/g" $HOME/.vim.local/bundles.vim
-  mv -f $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
+  mv -f $HOME/.vim.local/bundles.vim $DESTINATION/plugins.vim
   rm -f $HOME/.vim.local/bundles.vim.bak
   rmdir $HOME/.vim.local
 fi

--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,11 @@ EOF
 if [ -e $HOME/.haskell-vim-now ]; then
   msg "Migrating existing installation to $DESTINATION"
   mv -fu $HOME/.haskell-vim-now $DESTINATION
+  mv -fu $HOME/.vimrc.local $DESTINATION/vimrc.local
+  mv -fu $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
+  sed -i.bak "s/Plugin/Plug/g" $HOME/.vim.local/bundles.vim
+  mv -fu $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
+  rm -f $HOME/.vim.local/bundles.vim.bak
 fi
 
 if [ ! -e $DESTINATION/.git ]; then

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,7 @@ if [ -e $HOME/.haskell-vim-now ]; then
   sed -i.bak "s/Plugin/Plug/g" $HOME/.vim.local/bundles.vim
   mv -fu $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
   rm -f $HOME/.vim.local/bundles.vim.bak
+  rmdir $HOME/.vim.local
 fi
 
 if [ ! -e $DESTINATION/.git ]; then

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ if [ $? -ne 0 ] ; then
   exit 1
 fi
 
+
 msg "Installing system package dependencies"
 command -v brew >/dev/null
 if [ $? -eq 0 ] ; then
@@ -69,74 +70,89 @@ if [ $? -eq 0 ] ; then
   fi
 fi
 
-endpath="$HOME/.haskell-vim-now"
-
-if [ ! -e $endpath/.git ]; then
-  msg "Cloning begriffs/haskell-vim-now"
-  git clone https://github.com/begriffs/haskell-vim-now.git $endpath
+if [ -z ${XDG_CONFIG_HOME+x} ]; then
+  XDG_CONFIG_HOME="$HOME/.config"
+  msg "XDG_CONFIG_HOME is not set, using $XDG_CONFIG_HOME"
 else
-  msg "Existing installation detected"
-  msg "Updating from begriffs/haskell-vim-now"
-  cd $endpath && git pull
+  msg "XDG_CONFIG_HOME is set to $XDG_CONFIG_HOME"
 fi
-
-if [ -e ~/.vim/colors ]; then
-  msg "Preserving color scheme files"
-  cp -R ~/.vim/colors $endpath/colors
-fi
-
-today=`date +%Y%m%d_%H%M%S`
-msg "Backing up current vim config using timestamp $today"
-for i in $HOME/.vim $HOME/.vimrc $HOME/.gvimrc; do [ -e $i ] && mv $i $i.$today && detail "$i.$today"; done
-
-msg "Creating symlinks"
-detail "~/.vimrc -> $endpath/.vimrc"
-detail "~/.vim   -> $endpath/.vim"
-ln -sf $endpath/.vimrc $HOME/.vimrc
-if [ ! -d $endpath/.vim/bundle ]; then
-  mkdir -p $endpath/.vim/bundle
-fi
-ln -sf $endpath/.vim $HOME/.vim
-
-if [ ! -e $HOME/.vim/autoload/plug.vim ]; then
-  msg "Installing vim-plug"
-  curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-fi
-
-msg "Installing plugins using vim-plug..."
-vim -T dumb -E -u $endpath/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
+DESTINATION="$XDG_CONFIG_HOME/haskell-vim-now"
 
 msg "Setting up GHC if needed"
-stack setup
+stack setup --verbosity warning
+STACK_BIN_PATH=$(stack --verbosity 0 path --local-bin-path)
+STACK_GLOBAL=$(stack --verbosity 0 path --global-stack-root)
 
 msg "Adding extra stack deps if needed"
 DEPS_REGEX='s/extra-deps: \[\]/extra-deps: [cabal-helper-0.6.1.0, pure-cdb-0.1.1]/'
 # upgrade from a previous installation
 DEPS_UPGRADE_REGEX='s/cabal-helper-0.5.3.0/cabal-helper-0.6.1.0/g'
-sed -i.bak "$DEPS_REGEX" ~/.stack/global-project/stack.yaml || sed -i.bak "$DEPS_REGEX" ~/.stack/global/stack.yaml
-sed -i.bak "$DEPS_UPGRADE_REGEX" ~/.stack/global-project/stack.yaml || sed -i.bak "$DEPS_UPGRADE_REGEX" ~/.stack/global/stack.yaml
-rm -f ~/.stack/global/stack.yaml.bak ~/.stack/global-project/stack.yaml.bak
+sed -i.bak "$DEPS_REGEX" $STACK_GLOBAL/global-project/stack.yaml || sed -i.bak "$DEPS_REGEX" $STACK_GLOBAL/global/stack.yaml
+sed -i.bak "$DEPS_UPGRADE_REGEX" $STACK_GLOBAL/global-project/stack.yaml || sed -i.bak "$DEPS_UPGRADE_REGEX" $STACK_GLOBAL/global/stack.yaml
+rm -f $STACK_GLOBAL/global/stack.yaml.bak $STACK_GLOBAL/global-project/stack.yaml.bak
 
 msg "Installing helper binaries"
-stack --resolver nightly install ghc-mod hdevtools hasktags codex hscope pointfree pointful hoogle stylish-haskell
+stack --resolver nightly install ghc-mod hdevtools hasktags codex hscope pointfree pointful hoogle stylish-haskell --verbosity warning
 
 msg "Installing git-hscope"
-cp $endpath/git-hscope ~/.local/bin
+cp $DESTINATION/git-hscope $STACK_BIN_PATH
 
 msg "Building Hoogle database..."
-~/.local/bin/hoogle data
+$STACK_BIN_PATH/hoogle data
 
 msg "Setting git to use fully-pathed vim for messages..."
 git config --global core.editor $(which vim)
 
 msg "Configuring codex to search in stack..."
 cat > $HOME/.codex <<EOF
-hackagePath: $HOME/.stack/indices/Hackage/
+hackagePath: $STACK_GLOBAL/indices/Hackage/
 tagsFileHeader: false
 tagsFileSorted: false
 tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-absolute --output='\$TAGS' '\$SOURCES'
 EOF
+
+## Vim configuration steps
+
+if [ -e $HOME/.haskell-vim-now ]; then
+  msg "Migrating existing installation to $DESTINATION"
+  mv -fu $HOME/.haskell-vim-now $DESTINATION
+fi
+
+if [ ! -e $DESTINATION/.git ]; then
+  msg "Cloning begriffs/haskell-vim-now"
+  git clone https://github.com/begriffs/haskell-vim-now.git $DESTINATION
+else
+  msg "Existing installation detected"
+  msg "Updating from begriffs/haskell-vim-now"
+  cd $DESTINATION && git pull
+fi
+
+if [ -e ~/.vim/colors ]; then
+  msg "Preserving color scheme files"
+  cp -R ~/.vim/colors $DESTINATION/colors
+fi
+
+today=`date +%Y%m%d_%H%M%S`
+msg "Backing up current vim config using timestamp $today"
+if [ ! -e $DESTINATION/backup ]; then
+  mkdir $DESTINATION/backup
+fi
+for i in .vim .vimrc .gvimrc; do [ -e $HOME/$i ] && mv $HOME/$i $DESTINATION/backup/$i.$today && detail "$DESTINATION/backup/$i.$today"; done
+
+if [ ! -e $DESTINATION/.vim/autoload/plug.vim ]; then
+  msg "Installing vim-plug"
+  curl -fLo $DESTINATION/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
+
+msg "Creating symlinks"
+detail "~/.vimrc -> $DESTINATION/.vimrc"
+detail "~/.vim   -> $DESTINATION/.vim"
+ln -sf $DESTINATION/.vimrc $HOME/.vimrc
+ln -sf $DESTINATION/.vim $HOME/.vim
+
+msg "Installing plugins using vim-plug..."
+vim -T dumb -E -u $DESTINATION/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
 
 if [[ "$OSTYPE" =~ ^darwin ]]; then
   msg "NOTE FOR OS X USERS"

--- a/install.sh
+++ b/install.sh
@@ -145,17 +145,17 @@ if [ ! -e $DESTINATION/backup ]; then
 fi
 for i in .vim .vimrc .gvimrc; do [ -e $HOME/$i ] && mv $HOME/$i $DESTINATION/backup/$i.$today && detail "$DESTINATION/backup/$i.$today"; done
 
-if [ ! -e $DESTINATION/.vim/autoload/plug.vim ]; then
-  msg "Installing vim-plug"
-  curl -fLo $DESTINATION/.vim/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-fi
-
 msg "Creating symlinks"
 detail "~/.vimrc -> $DESTINATION/.vimrc"
 detail "~/.vim   -> $DESTINATION/.vim"
 ln -sf $DESTINATION/.vimrc $HOME/.vimrc
 ln -sf $DESTINATION/.vim $HOME/.vim
+
+if [ ! -e $DESTINATION/.vim/autoload/plug.vim ]; then
+  msg "Installing vim-plug"
+  curl -fLo $DESTINATION/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
 
 msg "Installing plugins using vim-plug..."
 vim -T dumb -E -u $DESTINATION/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall

--- a/install.sh
+++ b/install.sh
@@ -80,11 +80,11 @@ DESTINATION="$XDG_CONFIG_HOME/haskell-vim-now"
 
 if [ -e $HOME/.haskell-vim-now ]; then
   msg "Migrating existing installation to $DESTINATION"
-  mv -fu $HOME/.haskell-vim-now $DESTINATION
-  mv -fu $HOME/.vimrc.local $DESTINATION/vimrc.local
-  mv -fu $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
+  mv -f $HOME/.haskell-vim-now $DESTINATION
+  mv -f $HOME/.vimrc.local $DESTINATION/vimrc.local
+  mv -f $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
   sed -i.bak "s/Plugin '/Plug '/g" $HOME/.vim.local/bundles.vim
-  mv -fu $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
+  mv -f $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
   rm -f $HOME/.vim.local/bundles.vim.bak
   rmdir $HOME/.vim.local
 fi

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,26 @@ else
 fi
 DESTINATION="$XDG_CONFIG_HOME/haskell-vim-now"
 
+if [ -e $HOME/.haskell-vim-now ]; then
+  msg "Migrating existing installation to $DESTINATION"
+  mv -fu $HOME/.haskell-vim-now $DESTINATION
+  mv -fu $HOME/.vimrc.local $DESTINATION/vimrc.local
+  mv -fu $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
+  sed -i.bak "s/Plugin '/Plug '/g" $HOME/.vim.local/bundles.vim
+  mv -fu $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
+  rm -f $HOME/.vim.local/bundles.vim.bak
+  rmdir $HOME/.vim.local
+fi
+
+if [ ! -e $DESTINATION/.git ]; then
+  msg "Cloning begriffs/haskell-vim-now"
+  git clone https://github.com/begriffs/haskell-vim-now.git $DESTINATION
+else
+  msg "Existing installation detected"
+  msg "Updating from begriffs/haskell-vim-now"
+  cd $DESTINATION && git pull --rebase
+fi
+
 msg "Setting up GHC if needed"
 stack setup --verbosity warning
 STACK_BIN_PATH=$(stack --verbosity 0 path --local-bin-path)
@@ -112,26 +132,6 @@ tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-ab
 EOF
 
 ## Vim configuration steps
-
-if [ -e $HOME/.haskell-vim-now ]; then
-  msg "Migrating existing installation to $DESTINATION"
-  mv -fu $HOME/.haskell-vim-now $DESTINATION
-  mv -fu $HOME/.vimrc.local $DESTINATION/vimrc.local
-  mv -fu $HOME/.vimrc.local.pre $DESTINATION/vimrc.local.pre
-  sed -i.bak "s/Plugin/Plug/g" $HOME/.vim.local/bundles.vim
-  mv -fu $HOME/.vim.local/bundles.vim $DESTINATION/plugins.local
-  rm -f $HOME/.vim.local/bundles.vim.bak
-  rmdir $HOME/.vim.local
-fi
-
-if [ ! -e $DESTINATION/.git ]; then
-  msg "Cloning begriffs/haskell-vim-now"
-  git clone https://github.com/begriffs/haskell-vim-now.git $DESTINATION
-else
-  msg "Existing installation detected"
-  msg "Updating from begriffs/haskell-vim-now"
-  cd $DESTINATION && git pull
-fi
 
 if [ -e ~/.vim/colors ]; then
   msg "Preserving color scheme files"


### PR DESCRIPTION
* ~/.config/haskell-vim-now/ is the new project directory (DIR),
* .vimrc and .vim backups moved to DIR/backup/...,
* user configs placed to DIR/vimrc.local DIR/plugins.local,
* user now can use vimrc.local.pre to make configurations before .vimrc is executed,
* automated migration of user configs and installation (not sure i've done everything needed),
* installer now use stack to find it's configuration and bin path,
* README is correct now (vim-plug and new DIR).

The only thing you need to do is run new install.sh. It would move your installation of **haskell-vim-now** to `~/.config`, move `.vimrc.local` and `.vim.local/bundles.vim` to `~/.config/haskell-vim-now/vimrc.local` and `~/.config/haskell-vim-now/plugins.local` (**replacing Plugin directives with Plug**), then remove `~/.vim.local` directory **if it's empty** (if you store some other config files there, you need to move them manually).

Closes #99.