### PR TITLE
Decompose Installer

### DIFF
--- a/scripts/func.sh
+++ b/scripts/func.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Text color
+if which tput >/dev/null 2>&1; then
+    ncolors=$(tput colors)
+fi
+
+if [ -t 1 ] && [ -n "${ncolors}" ] && [ "${ncolors}" -ge 8 ]; then
+  RED="$(tput setaf 1)"
+  GREEN="$(tput setaf 2)"
+  YELLOW="$(tput setaf 3)"
+  BOLD="$(tput bold)"
+  NORMAL="$(tput sgr0)"
+else
+  RED=""
+  GREEN=""
+  YELLOW=""
+  BOLD=""
+  NORMAL=""
+fi
+
+msg() { echo -e "${GREEN}--- $@${NORMAL}" 1>&2; }
+warn() { echo -e "${YELLOW}${BOLD}--> $@${NORMAL}" 1>&2; }
+err() { echo -e "${RED}${BOLD}*** $@${NORMAL}" 1>&2; }
+detail() { echo -e "	$@" 1>&2; }
+verlte() {
+  [ "$1" = `echo -e "$1\n$2" | sort -t '.' -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -n1` ]
+}
+
+system_type() {
+  local platform
+  case ${OSTYPE} in
+    linux* ) platform="LINUX" ;;
+    darwin* ) platform="OSX" ;;
+    cygwin* ) platform="CYGWIN" ;;
+    * ) platform="OTHER" ;;
+  esac
+
+  echo ${platform}
+  return 0
+}
+
+config_home() {
+  local cfg_home
+  if [ -z ${XDG_CONFIG_HOME+x} ]; then
+    cfg_home="${HOME}/.config"
+  else
+    cfg_home=${XDG_CONFIG_HOME}
+  fi
+
+  echo ${cfg_home}
+  return 0
+}
+
+package_manager() {
+  local package_manager
+
+  if command -v brew >/dev/null 2>&1 ; then
+    package_manager="BREW"
+  elif command -v dnf >/dev/null 2>&1 ; then
+    package_manager="DNF"
+  elif command -v yum >/dev/null 2>&1 ; then
+    package_manager="YUM"
+  elif command -v apt-get >/dev/null 2>&1 ; then
+    package_manager="APT"
+  else
+    package_manager="OTHER"
+  fi
+
+  echo ${package_manager}
+  return 0
+}
+
+check_exist() {
+  local not_exist=()
+  for prg; do
+    if ! command -v ${prg} >/dev/null 2>&1; then
+      not_exist+=("${prg}")
+    fi
+  done
+  echo ${not_exist[@]}
+  return ${#not_exist[@]}
+}
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. ${SCRIPT_DIR}/func.sh
+
+setup() {
+  # $1 - optional - path to haskell-vim-now installation
+  #      If not set, script will use default location.
+  unset HVN_DEST
+  if [ -z $1 ] ; then
+    # No argument provided, using default path
+    HVN_DEST="$(config_home)/haskell-vim-now"
+  else
+    HVN_DEST=$1
+  fi
+  if [ ! -e ${HVN_DEST} ] ; then
+    err "${HVN_DEST} doesn't exist! Install Haskell-Vim-Now first!"
+    exit 1
+  fi
+
+  SYSTEM_TYPE=$(system_type)
+  PACKAGE_MGR=$(package_manager)
+  CONFIG_HOME=$(config_home)
+
+  BREW_LIST="git make vim ctags"
+  APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags fonts-powerline"
+  YUM_LIST="git make vim ctags libcurl-devel zlib-devel powerline"
+
+
+  if ! check_exist stack >/dev/null ; then
+    err "Installer requires Stack."
+    msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
+    exit 1
+  fi
+
+  msg "Installing system package dependencies..."
+  case ${PACKAGE_MGR} in
+    BREW )
+      msg "Installing with homebrew..."
+      brew install ${BREW_LIST}
+      ;;
+    APT )
+      msg "Installing with apt-get..."
+      sudo apt-get install -y ${APT_LIST}
+      ;;
+    DNF )
+      msg "Installing with DNF..."
+      sudo dnf install -yq ${YUM_LIST} # yum and dnf use same repos
+      ;;
+    YUM )
+      msg "Installing with YUM..."
+      sudo yum install -yq ${YUM_LIST}
+      ;;
+    OTHER )
+      warn "No package manager detected. You may need to install required packages manually."
+      ;;
+    * )
+      err "setup.sh is not configured to handle ${PACKAGE_MGR} manager! Aborting..."
+      exit 1
+  esac
+
+  NOT_INSTALLED=$(check_exist ctags curl-config git make vim)
+  if [ ! -z ${NOT_INSTALLED} ] ; then
+    err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
+    exit 1
+  fi
+
+  VIM_VER=$(vim --version | sed -n 's/^.*IMproved \([^ ]*\).*$/\1/p')
+  if ! verlte '7.4' ${VIM_VER} ; then
+    warn "Detected vim version \"${VIM_VER}\""
+    err "However version 7.4 or later is required. Aborting."
+    exit 1
+  fi
+
+  if vim --version | grep -q +ruby 2>&1 ; then
+    msg "Testing for broken Ruby interface in vim..."
+    vim -T dumb --cmd "ruby puts RUBY_VERSION" --cmd qa! 1>/dev/null 2>/dev/null
+    if [ $? -eq 0 ] ; then
+      msg "Test passed. Ruby interface is OK."
+    else
+      err "The Ruby interface is broken on your installation of vim."
+      err "Reinstall or recompile vim."
+      msg "If you're on OS X, try the following:"
+      detail "rvm use system"
+      detail "brew reinstall vim"
+      warn "If nothing helped, please report at https://github.com/begriffs/haskell-vim-now/issues"
+      exit 1
+    fi
+  fi
+
+  msg "Setting up GHC if needed..."
+  stack setup --verbosity warning
+  if [ $? -ne 0 ] ; then
+    err "Stack setup failed with error $?. Aborting..."
+    exit 1
+  fi
+
+  STACK_BIN_PATH=$(stack --verbosity 0 path --local-bin-path)
+  STACK_GLOBAL_DIR=$(stack --verbosity 0 path --global-stack-root)
+  STACK_GLOBAL_CONFIG=$(stack --verbosity 0 path --config-location)
+
+  detail "Stack bin path: ${STACK_BIN_PATH}"
+  detail "Stack global path: ${STACK_GLOBAL_DIR}"
+  detail "Stack global config location: ${STACK_GLOBAL_CONFIG}"
+
+  if [ -z ${STACK_BIN_PATH} ] || [ -z ${STACK_GLOBAL_DIR} ] || [ -z ${STACK_GLOBAL_CONFIG} ] ; then
+    err "Incorrect stack paths."
+    err "Please report at https://github.com/begriffs/haskell-vim-now/issues"
+    err "Aborting..."
+    exit 1
+  fi
+
+  msg "Adding extra stack deps if needed..."
+  DEPS_REGEX='s/extra-deps: \[\]/extra-deps: [cabal-helper-0.6.1.0, pure-cdb-0.1.1]/'
+  # upgrade from a previous installation
+  DEPS_UPGRADE_REGEX='s/cabal-helper-0.5.3.0/cabal-helper-0.6.1.0/g'
+  sed -i.bak "${DEPS_REGEX}" ${STACK_GLOBAL_CONFIG}
+  sed -i.bak "${DEPS_UPGRADE_REGEX}" ${STACK_GLOBAL_CONFIG}
+  rm -f ${STACK_GLOBAL_CONFIG}.bak
+
+  msg "Installing helper binaries..."
+  stack --resolver nightly install ghc-mod hdevtools hasktags codex hscope pointfree pointful hoogle stylish-haskell --verbosity warning
+  if [ $? -ne 0 ] ; then
+    err "Binary installation failed with error $?. Aborting..."
+    exit 1
+  fi
+
+  msg "Installing git-hscope..."
+  cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
+
+  msg "Building Hoogle database..."
+  ${STACK_BIN_PATH}/hoogle data
+
+  msg "Configuring codex to search in stack..."
+  cat > $HOME/.codex <<EOF
+hackagePath: $STACK_GLOBAL_DIR/indices/Hackage/
+tagsFileHeader: false
+tagsFileSorted: false
+tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-absolute --output='\$TAGS' '\$SOURCES'
+EOF
+
+  ## Vim configuration steps
+
+  if [ -e ~/.vim/colors ]; then
+    msg "Preserving color scheme files..."
+    cp -R ~/.vim/colors ${HVN_DEST}/colors
+  fi
+
+  today=`date +%Y%m%d_%H%M%S`
+  msg "Backing up current vim config using timestamp ${today}..."
+  if [ ! -e ${HVN_DEST}/backup ]; then
+    mkdir ${HVN_DEST}/backup
+  fi
+  for i in .vim .vimrc .gvimrc; do [ -e ${HOME}/${i} ] && mv ${HOME}/${i} ${HVN_DEST}/backup/${i}.${today} && detail "${HVN_DEST}/backup/${i}.${today}"; done
+
+  msg "Creating symlinks"
+  detail "~/.vimrc -> ${HVN_DEST}/.vimrc"
+  detail "~/.vim   -> ${HVN_DEST}/.vim"
+  ln -sf ${HVN_DEST}/.vimrc ${HOME}/.vimrc
+  ln -sf ${HVN_DEST}/.vim ${HOME}/.vim
+
+  if [ ! -e ${HVN_DEST}/.vim/autoload/plug.vim ]; then
+    msg "Installing vim-plug"
+    curl -fLo ${HVN_DEST}/.vim/autoload/plug.vim --create-dirs \
+      https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+  fi
+
+  msg "Installing plugins using vim-plug..."
+  vim -E -u ${HVN_DEST}/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
+
+  msg "Setting git to use fully-pathed vim for messages..."
+  git config --global core.editor $(which vim)
+
+  echo -e "\n"
+  msg "<---- HASKELL VIM NOW installation successfully finished ---->"
+  echo -e "\n"
+
+  case ${SYSTEM_TYPE} in
+    OSX )
+      warn "Note for OS X users:"
+      detail "Configure your terminal to use a font with Powerline symbols."
+      detail "https://powerline.readthedocs.org/en/master/installation/osx.html#fonts-installation"
+      ;;
+    LINUX )
+      warn "Note for Linux users:"
+      detail "Configure your terminal to use a font with Powerline symbols."
+      detail "https://powerline.readthedocs.org/en/master/installation/linux.html#fonts-installation"
+      ;;
+    * )
+      warn "Note for users:"
+      detail "Configure your terminal to use a font with Powerline symbols."
+      detail "https://github.com/powerline/fonts"
+      ;;
+  esac
+}


### PR DESCRIPTION
install.sh is responsible for haskell-vim-now repo clone (and pull) and
should be kept as simple and short as possible. Everything else is done
in setup.sh.

Other improvements:
* Paint printed messages with red, green and yellow colors;
* Split actions in functions (install, setup);
* Stack global config is obtained with "stack path" command (not hard-
coded anymore);
* Installer now prints all missing programms, not one-by-one;
* Add checks for empty stack paths;
* Add checks for "stack setup" and "stack install" return codes;
* Don't use dumb terminal with vim-plug (it erases lines from terminal);
* Add some more messages;

General cleanups and reformating. Code is now easier to read.

Closes #105. Not complete, though. Need to split setup.sh some more (to setup.sh and update.sh). But for now it's enough for user to simply run install.sh from their installation, not curl.