### PR TITLE
Add space to Hoogle commands where input is required.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -655,13 +655,13 @@ let g:syntastic_haskell_hdevtools_args = '-g-Wall'
 nnoremap <silent> <leader>hh :Hoogle<CR>
 
 " Hoogle and prompt for input
-nnoremap <leader>hH :Hoogle
+nnoremap <leader>hH :Hoogle 
 
 " Hoogle for detailed documentation (e.g. "Functor")
 nnoremap <silent> <leader>hi :HoogleInfo<CR>
 
 " Hoogle for detailed documentation and prompt for input
-nnoremap <leader>hI :HoogleInfo
+nnoremap <leader>hI :HoogleInfo 
 
 " Hoogle, close the Hoogle window
 nnoremap <silent> <leader>hz :HoogleClose<CR>


### PR DESCRIPTION
The current bindings for the Hoogle commands that require user input can include the space automatically so the user doesn't have to worry about it.