### PR TITLE
Add neovim specific settings and symlinking support

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -74,13 +74,22 @@ let $PATH = $PATH . ':' . expand(hvn_stack_bin)
 " Kill the damned Ex mode.
 nnoremap Q <nop>
 
+" Make <c-h> work like <c-h> again (this is a problem with libterm)
+if has('nvim')
+  nnoremap <BS> <C-w>h
+endif
+
 " }}}
 
 " vim-plug {{{
 
 set nocompatible
 
-call plug#begin('~/.vim/bundle')
+if has('nvim')
+  call plug#begin('~/.config/nvim/bundle')
+else
+  call plug#begin('~/.vim/bundle')
+endif
 
 " Support bundles
 Plug 'jgdavey/tslime.vim'
@@ -246,7 +255,11 @@ endif
 set t_Co=256
 
 " Set utf8 as standard encoding and en_US as the standard language
-set encoding=utf8
+if !has('nvim')
+  " Only set this for vim, since neovim is utf8 as default and setting it
+  " causes problems when reloading the .vimrc configuration
+  set encoding=utf8
+endif
 
 " Use Unix as the standard file type
 set ffs=unix,dos,mac
@@ -273,7 +286,11 @@ set noswapfile
 " Source the vimrc file after saving it
 augroup sourcing
   autocmd!
-  autocmd bufwritepost .vimrc source $MYVIMRC
+  if has('nvim')
+    autocmd bufwritepost init.vim source $MYVIMRC
+  else
+    autocmd bufwritepost .vimrc source $MYVIMRC
+  endif
 augroup END
 
 " Open file prompt with current path
@@ -394,6 +411,18 @@ noremap <leader>bd :Bd<cr>
 
 " fuzzy find buffers
 noremap <leader>b<space> :CtrlPBuffer<cr>
+
+" Neovim terminal configurations
+if has('nvim')
+  " Use <Esc> to escape terminal insert mode
+  tnoremap <Esc> <C-\><C-n>
+  " Make terminal split moving behave like normal neovim
+  tnoremap <c-h> <C-\><C-n><C-w>h
+  tnoremap <c-j> <C-\><C-n><C-w>j
+  tnoremap <c-k> <C-\><C-n><C-w>k
+  tnoremap <c-l> <C-\><C-n><C-w>l
+endif
+
 
 " }}}
 
@@ -655,13 +684,13 @@ let g:syntastic_haskell_hdevtools_args = '-g-Wall'
 nnoremap <silent> <leader>hh :Hoogle<CR>
 
 " Hoogle and prompt for input
-nnoremap <leader>hH :Hoogle 
+nnoremap <leader>hH :Hoogle
 
 " Hoogle for detailed documentation (e.g. "Functor")
 nnoremap <silent> <leader>hi :HoogleInfo<CR>
 
 " Hoogle for detailed documentation and prompt for input
-nnoremap <leader>hI :HoogleInfo 
+nnoremap <leader>hI :HoogleInfo
 
 " Hoogle, close the Hoogle window
 nnoremap <silent> <leader>hz :HoogleClose<CR>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,7 +29,7 @@ setup() {
     msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
     exit 1
   fi
-
+  r
   msg "Installing system package dependencies..."
   case ${PACKAGE_MGR} in
     BREW )
@@ -135,10 +135,10 @@ EOF
   fi
 
   today=`date +%Y%m%d_%H%M%S`
-  msg "Backing up current vim config using timestamp ${today}..."
+  msg "Backing up current vim/nvim config using timestamp ${today}..."
   [ ! -e ${HVN_DEST}/backup ] && mkdir ${HVN_DEST}/backup
 
-  for i in .vim .vimrc .gvimrc; do [ -e ${HOME}/${i} ] && mv ${HOME}/${i} ${HVN_DEST}/backup/${i}.${today} && detail "${HVN_DEST}/backup/${i}.${today}"; done
+  for i in .vim .vimrc .gvimrc .config/nvim; do [ -e ${HOME}/${i} ] && mv ${HOME}/${i} ${HVN_DEST}/backup/${i}.${today} && detail "${HVN_DEST}/backup/${i}.${today}"; done
 
   msg "Creating symlinks"
   detail "~/.vimrc -> ${HVN_DEST}/.vimrc"
@@ -156,6 +156,16 @@ EOF
 
   msg "Installing plugins using vim-plug..."
   vim -E -u ${HVN_DEST}/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
+
+  msg "Creating folder for Neovim"
+  mkdir -p .config/nvim
+  msg "Creating Neovim symlinks"
+  detail "~/.config/nvim/init.vim -> ${HVN_DEST}/.vimrc"
+  ln -sf ${HVN_DEST}/.vimrc ${HOME}/.config/nvim/init.vim
+  detail "~/.config/nvim/bundle -> ${HVN_DEST}/.vim/bundle"
+  ln -sf ${HVN_DEST}/.vim/bundle ${HOME}/.config/nvim/bundle
+  detail "~/.config/nvim/autoload -> ${HVN_DEST}/.vim/autoload"
+  ln -sf ${HVN_DEST}/.vim/autoload ${HOME}/.config/nvim/autoload
 
   msg "Setting git to use fully-pathed vim for messages..."
   git config --global core.editor $(which vim)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,7 +29,6 @@ setup() {
     msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
     exit 1
   fi
-  r
   msg "Installing system package dependencies..."
   case ${PACKAGE_MGR} in
     BREW )


### PR DESCRIPTION
Backup any existing neovim configuration, and symlink the HVN configuration
into ~/.config/nvim/. 

Also adds some neovim specific settings into the .vimrc, wrapped in checks for
has('nvim'), so they don't affect normal vim.

This closes #87 and closes #114.