### PR TITLE
Improved Neovim support and script to replace configs

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -74,13 +74,22 @@ let $PATH = $PATH . ':' . expand(hvn_stack_bin)
 " Kill the damned Ex mode.
 nnoremap Q <nop>
 
+" Make <c-h> work like <c-h> again (this is a problem with libterm)
+if has('nvim')
+  nnoremap <BS> <C-w>h
+endif
+
 " }}}
 
 " vim-plug {{{
 
 set nocompatible
 
-call plug#begin('~/.vim/bundle')
+if has('nvim')
+  call plug#begin('~/.config/nvim/bundle')
+else
+  call plug#begin('~/.vim/bundle')
+endif
 
 " Support bundles
 Plug 'jgdavey/tslime.vim'
@@ -246,7 +255,11 @@ endif
 set t_Co=256
 
 " Set utf8 as standard encoding and en_US as the standard language
-set encoding=utf8
+if !has('nvim')
+  " Only set this for vim, since neovim is utf8 as default and setting it
+  " causes problems when reloading the .vimrc configuration
+  set encoding=utf8
+endif
 
 " Use Unix as the standard file type
 set ffs=unix,dos,mac
@@ -273,7 +286,11 @@ set noswapfile
 " Source the vimrc file after saving it
 augroup sourcing
   autocmd!
-  autocmd bufwritepost .vimrc source $MYVIMRC
+  if has('nvim')
+    autocmd bufwritepost init.vim source $MYVIMRC
+  else
+    autocmd bufwritepost .vimrc source $MYVIMRC
+  endif
 augroup END
 
 " Open file prompt with current path
@@ -394,6 +411,18 @@ noremap <leader>bd :Bd<cr>
 
 " fuzzy find buffers
 noremap <leader>b<space> :CtrlPBuffer<cr>
+
+" Neovim terminal configurations
+if has('nvim')
+  " Use <Esc> to escape terminal insert mode
+  tnoremap <Esc> <C-\><C-n>
+  " Make terminal split moving behave like normal neovim
+  tnoremap <c-h> <C-\><C-n><C-w>h
+  tnoremap <c-j> <C-\><C-n><C-w>j
+  tnoremap <c-k> <C-\><C-n><C-w>k
+  tnoremap <c-l> <C-\><C-n><C-w>l
+endif
+
 
 " }}}
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ then add `unmap <c-l>` to your vimrc.local)
 
 After installing this configuration, your `.vimrc` and `.vim` will
 be under version control. Don't alter these files. Instead, add your
-own settings to `~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local`  and `~/.config/haskell-vim-now/plugins.vim`.
+own settings to `~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local` and `~/.config/haskell-vim-now/plugins.vim`.
 
 ## Adding Custom Plugs
 
@@ -312,6 +312,21 @@ this restriction, `.vimrc` sources `~/.config/haskell-vim-now/plugins.vim` immed
 after its own Plug statements.
 
 Plug statements made elsewhere are not recognized.
+
+## Neovim support
+
+The `.vimrc` configuration is fully compatible with Neovim, and adds a few
+Neovim specific mappings for the terminal mode (terminal emulation is activated
+with `:terminal`). The mappings make `Esc` and `c-[hjkl]` function as one would
+expect them to from normal mode.
+
+The Neovim configuration is found at '.config/nvim`, and is symlinked just like
+regular vim, which means you should only add your own settings to
+`~/.config/haskell-vim-now/vimrc.local.pre`, `~/.config/haskell-vim-now/vimrc.local`
+and `~/.config/haskell-vim-now/plugins.vim`.
+
+You can quickly backup and replace your Neovim setup by running the `scripts/neovim.sh`
+script.
 
 ### Docker image
 

--- a/scripts/neovim.sh
+++ b/scripts/neovim.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. ${SCRIPT_DIR}/func.sh
+
+setup() {
+  # $1 - optional - path to haskell-vim-now installation
+  #      If not set, script will use default location.
+  unset HVN_DEST
+  if [ -z $1 ] ; then
+    # No argument provided, using default path
+    HVN_DEST="$(config_home)/haskell-vim-now"
+  else
+    HVN_DEST=$1
+  fi
+  [ ! -e ${HVN_DEST} ] && exit_err "${HVN_DEST} doesn't exist! Install Haskell-Vim-Now first!"
+
+
+  ## Neovim configuration steps
+
+  today=`date +%Y%m%d_%H%M%S`
+  msg "Backing up current nvim config using timestamp ${today}..."
+  [ ! -e ${HVN_DEST}/backup ] && mkdir ${HVN_DEST}/backup
+
+  [ -e ${HOME}/.config/nvim ] && mv ${HOME}/.config/nvim ${HVN_DEST}/backup/nvim.${today} && detail "${HVN_DEST}/backup/nvim.${today}"
+
+  msg "Creating folder for Neovim"
+  mkdir -p ${HOME}/.config/nvim
+
+  msg "Creating symlinks"
+  detail "~/.config/nvim/init.vim -> ${HVN_DEST}/.vimrc"
+  ln -sf ${HVN_DEST}/.vimrc ${HOME}/.config/nvim/init.vim
+  detail "~/.config/nvim/bundle -> ${HVN_DEST}/.vim/bundle"
+  ln -sf ${HVN_DEST}/.vim/bundle ${HOME}/.config/nvim/bundle
+  detail "~/.config/nvim/autoload -> ${HVN_DEST}/.vim/autoload"
+  ln -sf ${HVN_DEST}/.vim/autoload ${HOME}/.config/nvim/autoload
+
+  echo -e "\n"
+  msg "<---- HASKELL VIM NOW Neovim setup successfully finished ---->"
+  echo -e "\n"
+}
+
+main() {
+  setup ${HVN_DEST}
+}
+
+main

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -164,7 +164,10 @@ EOF
   msg "<---- HASKELL VIM NOW installation successfully finished ---->"
   echo -e "\n"
 
+  detail "If you want to use HASKELL VIM NOW with Neovim, you can run ${HOME}/${HVN_DEST}/scripts/neovim.sh to backup your existing configuration and symlink the new one."
+
   warn "Note for a good-looking vim experience:"
   detail "Configure your terminal to use a font with Powerline symbols."
   detail "https://powerline.readthedocs.org/en/master/installation.html#fonts-installation"
+
 }


### PR DESCRIPTION
Add script to backup any existing neovim configuration, and symlink the HVN configuration
into ~/.config/nvim/.

Also adds some neovim specific settings into the .vimrc, wrapped in checks for
has('nvim'), so they don't affect normal vim.

This closes #87 and closes #114. Sorry for the duplicate pull request in #123.