### PR TITLE
Fixes for #142 and #143.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -13,11 +13,8 @@ let hvn_config_pre = expand(resolve(hvn_config_dir . "/vimrc.local.pre"))
 let hvn_config_post = expand(resolve(hvn_config_dir . "/vimrc.local"))
 " user plugins config path
 let hvn_user_plugins = expand(resolve(hvn_config_dir . "/plugins.vim"))
-
 " stack bin path symlink
 let hvn_stack_bin = expand(resolve(hvn_config_dir . "/.stack-bin"))
-" stack global path symlink
-" let hvn_stack_global = expand(resolve(hvn_config_dir . "/.stack"))
 " }}}
 
 " Precustomization {{{
@@ -69,7 +66,7 @@ set formatprg="PARINIT='rTbgqR B=.,?_A_a Q=_s>|' par\ -w72"
 autocmd FileType haskell let &formatprg="stylish-haskell"
 
 " Find custom built hasktags, codex etc
-let $PATH = $PATH . ':' . expand(hvn_stack_bin)
+let $PATH = expand(hvn_stack_bin) . ':' . $PATH
 
 " Include correct GHC binaries in path
 let $PATH=system('stack path --bin-path')

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,7 +87,7 @@ setup() {
   [ ${RETCODE} -ne 0 ] && exit_err "Requires exuberant-ctags, not just ctags."
 
   msg "Setting up GHC if needed..."
-  stack setup --resolver nightly-2015-12-08 --verbosity warning ; RETCODE=$?
+  stack setup --resolver lts-4.2 --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && exit_err "Stack setup failed with error ${RETCODE}. Aborting..."
 
   STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin-path))
@@ -114,7 +114,7 @@ setup() {
   rm -f ${STACK_GLOBAL_CONFIG}.bak
 
   msg "Installing helper binaries..."
-  stack --resolver nightly-2015-12-08 install ghc-mod hdevtools hlint hasktags codex hscope pointfree-1.1 pointful-1.0.6 hoogle stylish-haskell --verbosity warning ; RETCODE=$?
+  stack --resolver lts-4.2 install ghc-mod hdevtools hlint hasktags codex hscope pointfree pointful hoogle stylish-haskell --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && err "Binary installation failed with error ${RETCODE}. Aborting..."
 
   msg "Installing git-hscope..."


### PR DESCRIPTION
Remove the pinned nightly Stackage snapshot, using LTS-4.2 instead.  Remove the pinned pointful and pointfree versions.  Fix issue observed in clean install on OS X where the PATH for vim gets confused.