### PR TITLE
Fix deprecated `stack path` options

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -104,8 +104,8 @@ setup() {
   stack setup --resolver ${STACK_RESOLVER} --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && exit_err "Stack setup failed with error ${RETCODE}. Aborting..."
 
-  STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin-path))
-  STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --global-stack-root))
+  STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin))
+  STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --stack-root))
   STACK_GLOBAL_CONFIG=$(fix_path $(stack --verbosity 0 path --config-location))
 
   detail "Stack bin path: ${STACK_BIN_PATH}"


### PR DESCRIPTION
Due to latest stack's warnings:
'--local-bin-path' will be removed in a future release.
'--global-stack-root' will be removed in a future release.