### PR TITLE
Fix paragraph formatting with par

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -60,7 +60,8 @@ set tm=2000
 noremap ,, ,
 
 " Use par for prettier line formatting
-set formatprg="PARINIT='rTbgqR B=.,?_A_a Q=_s>|' par\ -w72"
+set formatprg=par
+let $PARINIT = 'rTbgqR B=.,?_A_a Q=_s>|'
 
 " Use stylish haskell instead of par for haskell buffers
 autocmd FileType haskell let &formatprg="stylish-haskell"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,7 +32,7 @@ setup() {
   local CONFIG_HOME=$(config_home)
 
   local BREW_LIST="git homebrew/dupes/make vim ctags par"
-  local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags fonts-powerline par"
+  local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags par"
   local YUM_LIST="git make vim ctags libcurl-devel zlib-devel powerline"
   local STACK_LIST="ghc-mod hlint hasktags codex hscope pointfree pointful hoogle stylish-haskell apply-refact"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,8 +31,8 @@ setup() {
   local PACKAGE_MGR=$(package_manager)
   local CONFIG_HOME=$(config_home)
 
-  local BREW_LIST="git homebrew/dupes/make vim ctags"
-  local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags fonts-powerline"
+  local BREW_LIST="git homebrew/dupes/make vim ctags par"
+  local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags fonts-powerline par"
   local YUM_LIST="git make vim ctags libcurl-devel zlib-devel powerline"
   local STACK_LIST="ghc-mod hlint hasktags codex hscope pointfree pointful hoogle stylish-haskell apply-refact"
 
@@ -68,7 +68,7 @@ setup() {
       exit_err_report "setup.sh is not configured to handle ${PACKAGE_MGR} manager."
   esac
 
-  local NOT_INSTALLED=$(check_exist ctags curl-config git make vim)
+  local NOT_INSTALLED=$(check_exist ctags curl-config git make vim par)
   [ ! -z ${NOT_INSTALLED} ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
 
   local VIM_VER=$(vim --version | sed -n 's/^.*IMproved \([^ ]*\).*$/\1/p')


### PR DESCRIPTION
Fixes #135

Sadly there is no RPM package for the `par` command that I could find so on CentOS the installer will fail and prompt the user to install it themselves. They will have to figure out how to build from source.