### PR TITLE
Refactor to allow a basic setup without Haskell components

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ and `~/.config/haskell-vim-now/plugins.vim`.
 You can quickly backup and replace your Neovim setup by running the `scripts/neovim.sh`
 script.
 
-### Docker image
+## Docker image
 
 If you are into developing with Docker, you can use the image.
 
@@ -354,11 +354,39 @@ If instead you want to extract the vim setup from the image that is easy enough
 
 However, some things (for example the hoogle database) use absolute paths and don't work correctly.
 
-### Troubleshooting
+## Advanced install methods
+
+### Basic install
+In case you want to skip the haskell specific components and want to install
+just the common vim config you can use:
+```sh
+bash <(curl -sL https://git.io/haskell-vim-now) --basic
+```
+
+### Installing from a fork or clone
+If you have a modified fork you can use the `--repo` option to tell the install
+script the location of your repository:
+```sh
+bash <(curl -sL INSTALL-SCRIPT-URL) --repo FORK-URL
+```
+
+For example:
+
+```sh
+bash <(curl -sL https://raw.githubusercontent.com/begriffs/haskell-vim-now/master/install.sh) --repo https://github.com/begriffs/haskell-vim-now
+```
+
+If you have a local git clone you can use `install.sh` directly
+to install from your clone:
+```sh
+install.sh --repo CLONE-PATH
+```
+
+## Troubleshooting
 
 See this [wiki](https://github.com/begriffs/haskell-vim-now/wiki/Installation-Troubleshooting)
 page for tips on fixing installation problems.
 
-### Thank you!
+## Thank you!
 
 Big thanks to [contributors](https://github.com/begriffs/haskell-vim-now/graphs/contributors). I'd especially like to thank [@SX91](https://github.com/SX91) for rewriting the installer and for other major improvements.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,7 +20,7 @@ setup_haskell() {
 
   if ! check_exist stack >/dev/null ; then
     err "Installer requires Stack."
-    msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
+    msg "Installation instructions: http://docs.haskellstack.org/en/stable/README/#how-to-install"
     exit 1
   fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -167,7 +167,7 @@ vim_setup_links() {
   ln -sf ${HVN_DEST}/.vim ${HOME}/.vim
 }
 
-vim_install_plugins() {
+vim_install_plug() {
   local HVN_DEST=$1
 
   if [ ! -e ${HVN_DEST}/.vim/autoload/plug.vim ]; then
@@ -176,7 +176,9 @@ vim_install_plugins() {
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
       || exit_err_report "Failed to install vim-plug."
   fi
+}
 
+vim_install_plugins() {
   msg "Installing plugins using vim-plug..."
   vim -E -u ${HVN_DEST}/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
 }
@@ -185,12 +187,13 @@ setup_vim() {
   local HVN_DEST=$1
 
   vim_check_version
-  vim_install_plugins $HVN_DEST
+  vim_install_plug $HVN_DEST
 
   # Point of no return; we cannot fail after this.
   # Backup old config and switch to new config
   vim_backup          $HVN_DEST
   vim_setup_links     $HVN_DEST
+  vim_install_plugins $HVN_DEST
 }
 
 setup_done() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . ${SCRIPT_DIR}/func.sh
 
 stack_resolver() {
-  local DEFAULT_RESOLVER=lts-5
+  local DEFAULT_RESOLVER=lts
   local CONFIGURED=$( sed -rn 's/^resolver:\s*(\S+).*$/\1/p' "$1" 2>/dev/null )
   if [ -z $CONFIGURED ]; then
     echo $DEFAULT_RESOLVER
@@ -173,7 +173,8 @@ vim_install_plugins() {
   if [ ! -e ${HVN_DEST}/.vim/autoload/plug.vim ]; then
     msg "Installing vim-plug"
     curl -fLo ${HVN_DEST}/.vim/autoload/plug.vim --create-dirs \
-      https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+      https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
+      || exit_err_report "Failed to install vim-plug."
   fi
 
   msg "Installing plugins using vim-plug..."
@@ -184,9 +185,12 @@ setup_vim() {
   local HVN_DEST=$1
 
   vim_check_version
+  vim_install_plugins $HVN_DEST
+
+  # Point of no return; we cannot fail after this.
+  # Backup old config and switch to new config
   vim_backup          $HVN_DEST
   vim_setup_links     $HVN_DEST
-  vim_install_plugins $HVN_DEST
 }
 
 setup_done() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,19 +14,65 @@ stack_resolver() {
   return 0
 }
 
-setup() {
-  # $1 - optional - path to haskell-vim-now installation
-  #      If not set, script will use default location.
-  unset HVN_DEST
-  local HVN_DEST
-  if [ -z $1 ] ; then
-    # No argument provided, using default path
-    HVN_DEST="$(config_home)/haskell-vim-now"
-  else
-    HVN_DEST=$1
-  fi
-  [ ! -e ${HVN_DEST} ] && exit_err "${HVN_DEST} doesn't exist! Install Haskell-Vim-Now first!"
+setup_haskell() {
+  local HVN_DEST=$1
+  local RETCODE
 
+  if ! check_exist stack >/dev/null ; then
+    err "Installer requires Stack."
+    msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
+    exit 1
+  fi
+
+  msg "Setting up GHC if needed..."
+  stack setup --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Stack setup failed with error ${RETCODE}."
+
+  if [ $(stack --verbosity 0 path --local-bin 2> /dev/null) ]
+  then
+    local STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin))
+    local STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --stack-root))
+    local STACK_GLOBAL_CONFIG=$(fix_path $(stack --verbosity 0 path --config-location))
+  else
+    local STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin-path))
+    local STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --global-stack-root))
+    local STACK_GLOBAL_CONFIG=$(fix_path $(stack --verbosity 0 path --config-location))
+  fi
+  local STACK_RESOLVER=$(stack_resolver $STACK_GLOBAL_CONFIG)
+
+  detail "Stack bin path: ${STACK_BIN_PATH}"
+  detail "Stack global path: ${STACK_GLOBAL_DIR}"
+  detail "Stack global config location: ${STACK_GLOBAL_CONFIG}"
+  detail "Stack resolver: ${STACK_RESOLVER}"
+
+  if [ -z ${STACK_BIN_PATH} ] || [ -z ${STACK_GLOBAL_DIR} ] || [ -z ${STACK_GLOBAL_CONFIG} ] ; then
+    exit_err_report "Incorrect stack paths."
+  fi
+
+  detail "${HVN_DEST}/.stack-bin -> ${STACK_BIN_PATH}"
+  ln -sf ${STACK_BIN_PATH} ${HVN_DEST}/.stack-bin
+
+  msg "Installing helper binaries..."
+  local STACK_LIST="ghc-mod hlint hasktags codex hscope pointfree pointful hoogle hindent apply-refact"
+  stack --resolver ${STACK_RESOLVER} install ${STACK_LIST} --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Binary installation failed with error ${RETCODE}."
+
+  msg "Installing git-hscope..."
+  cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
+
+  msg "Building Hoogle database..."
+  ${STACK_BIN_PATH}/hoogle data
+
+  msg "Configuring codex to search in stack..."
+  cat > $HOME/.codex <<EOF
+hackagePath: $STACK_GLOBAL_DIR/indices/Hackage/
+tagsFileHeader: false
+tagsFileSorted: false
+tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-absolute --output='\$TAGS' '\$SOURCES'
+EOF
+}
+
+setup_tools() {
   local SYSTEM_TYPE=$(system_type)
   local PACKAGE_MGR=$(package_manager)
   local CONFIG_HOME=$(config_home)
@@ -34,14 +80,6 @@ setup() {
   local BREW_LIST="git homebrew/dupes/make vim ctags par"
   local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags par"
   local YUM_LIST="git make vim ctags libcurl-devel zlib-devel powerline"
-  local STACK_LIST="ghc-mod hlint hasktags codex hscope pointfree pointful hoogle hindent apply-refact"
-
-
-  if ! check_exist stack >/dev/null ; then
-    err "Installer requires Stack."
-    msg "Installation instructions: https://github.com/commercialhaskell/stack#how-to-install"
-    exit 1
-  fi
 
   msg "Installing system package dependencies..."
   case ${PACKAGE_MGR} in
@@ -71,6 +109,16 @@ setup() {
   local NOT_INSTALLED=$(check_exist ctags curl-config git make vim par)
   [ ! -z ${NOT_INSTALLED} ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
 
+  msg "Checking ctags' exuberance..."
+  local RETCODE
+  ctags --version | grep -q Exuberant ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Requires exuberant-ctags, not just ctags."
+
+  msg "Setting git to use fully-pathed vim for messages..."
+  git config --global core.editor $(which vim)
+}
+
+vim_check_version() {
   local VIM_VER=$(vim --version | sed -n 's/^.*IMproved \([^ ]*\).*$/\1/p')
   if ! verlte '7.4' ${VIM_VER} ; then
     exit_err "Detected vim version \"${VIM_VER}\", however version 7.4 or later is required."
@@ -91,57 +139,10 @@ setup() {
       exit 1
     fi
   fi
+}
 
-  local RETCODE
-  msg "Checking ctags' exuberance..."
-  ctags --version | grep -q Exuberant ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Requires exuberant-ctags, not just ctags."
-
-  msg "Setting up GHC if needed..."
-  stack setup --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Stack setup failed with error ${RETCODE}."
-
-  if [ $(stack --verbosity 0 path --local-bin 2> /dev/null) ]
-  then
-    local STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin))
-    local STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --stack-root))
-    local STACK_GLOBAL_CONFIG=$(fix_path $(stack --verbosity 0 path --config-location))
-  else
-    local STACK_BIN_PATH=$(fix_path $(stack --verbosity 0 path --local-bin-path))
-    local STACK_GLOBAL_DIR=$(fix_path $(stack --verbosity 0 path --global-stack-root))
-    local STACK_GLOBAL_CONFIG=$(fix_path $(stack --verbosity 0 path --config-location))
-  fi
-
-  local STACK_RESOLVER=$(stack_resolver $STACK_GLOBAL_CONFIG)
-
-  detail "Stack bin path: ${STACK_BIN_PATH}"
-  detail "Stack global path: ${STACK_GLOBAL_DIR}"
-  detail "Stack global config location: ${STACK_GLOBAL_CONFIG}"
-  detail "Stack resolver: ${STACK_RESOLVER}"
-
-  if [ -z ${STACK_BIN_PATH} ] || [ -z ${STACK_GLOBAL_DIR} ] || [ -z ${STACK_GLOBAL_CONFIG} ] ; then
-    exit_err_report "Incorrect stack paths."
-  fi
-
-  msg "Installing helper binaries..."
-  stack --resolver ${STACK_RESOLVER} install ${STACK_LIST} --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Binary installation failed with error ${RETCODE}."
-
-  msg "Installing git-hscope..."
-  cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
-
-  msg "Building Hoogle database..."
-  ${STACK_BIN_PATH}/hoogle data
-
-  msg "Configuring codex to search in stack..."
-  cat > $HOME/.codex <<EOF
-hackagePath: $STACK_GLOBAL_DIR/indices/Hackage/
-tagsFileHeader: false
-tagsFileSorted: false
-tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-absolute --output='\$TAGS' '\$SOURCES'
-EOF
-
-  ## Vim configuration steps
+vim_backup () {
+  local HVN_DEST=$1
 
   if [ -e ~/.vim/colors ]; then
     msg "Preserving color scheme files..."
@@ -153,14 +154,21 @@ EOF
   [ ! -e ${HVN_DEST}/backup ] && mkdir ${HVN_DEST}/backup
 
   for i in .vim .vimrc .gvimrc; do [ -e ${HOME}/${i} ] && mv ${HOME}/${i} ${HVN_DEST}/backup/${i}.${today} && detail "${HVN_DEST}/backup/${i}.${today}"; done
+}
 
-  msg "Creating symlinks"
+vim_setup_links() {
+  local HVN_DEST=$1
+
+  msg "Creating vim config symlinks"
   detail "~/.vimrc -> ${HVN_DEST}/.vimrc"
   ln -sf ${HVN_DEST}/.vimrc ${HOME}/.vimrc
+
   detail "~/.vim   -> ${HVN_DEST}/.vim"
   ln -sf ${HVN_DEST}/.vim ${HOME}/.vim
-  detail "${HVN_DEST}/.stack-bin -> ${STACK_BIN_PATH}"
-  ln -sf ${STACK_BIN_PATH} ${HVN_DEST}/.stack-bin
+}
+
+vim_install_plugins() {
+  local HVN_DEST=$1
 
   if [ ! -e ${HVN_DEST}/.vim/autoload/plug.vim ]; then
     msg "Installing vim-plug"
@@ -170,9 +178,19 @@ EOF
 
   msg "Installing plugins using vim-plug..."
   vim -E -u ${HVN_DEST}/.vimrc +PlugUpgrade +PlugUpdate +PlugClean! +qall
+}
 
-  msg "Setting git to use fully-pathed vim for messages..."
-  git config --global core.editor $(which vim)
+setup_vim() {
+  local HVN_DEST=$1
+
+  vim_check_version
+  vim_backup          $HVN_DEST
+  vim_setup_links     $HVN_DEST
+  vim_install_plugins $HVN_DEST
+}
+
+setup_done() {
+  local HVN_DEST=$1
 
   echo -e "\n"
   msg "<---- HASKELL VIM NOW installation successfully finished ---->"


### PR DESCRIPTION
The first commit is a refactor without changing any existing functionality. I have taken care that no behavior changes unless something might have crept in inadvertently.

Other than the refactor, it adds two command line options to install.sh. One for a basic installation without Haskell components and another to specify a repo to install from. I am providing the motivation for both below.

Basic Installation: haskell vim now has pretty good common (non-haskell) settings as well. I want to use the same setup even where I do not use haskell or in setups where installing stack and GHC would take too much space and time even though I won't need them. Now, I can just provide an option to install and have the same setup elsewhere as well. Even non-haskell users can now use haskell-vim-now, maybe we can call it vim-now instead!

Please note that it does not change or break anything for the existing end users.

repo path: I added this mainly for testing so that I could easily specify my git clone as the repo when running install.sh.

The second commit is to avoid confusion about the powerline fonts. I interpreted the message as the fonts have to be installed and configured though it was already installed only to be configured. I made that clear in the message.