### PR TITLE
support macports, package install bug fix, ensure curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,15 +133,29 @@ function usage() {
   exit 1
 }
 
-REPO_PATH=$DEFAULT_REPO
+# $1: envvar
+check_boolean_var() {
+  local var=$(eval "echo \$$1")
+  if test -n "$var" -a "$var" != y
+  then
+    >&2 echo "Error: Boolean envvar [$1] can only be empty or 'y'"
+    exit 1
+  fi
+  echo "ENV: [$1=$var]"
+}
+
+# command line args override env vars
+HVN_REPO=${HVN_REPO:=$DEFAULT_REPO}
+check_boolean_var HVN_INSTALL_BASIC
+
 while test -n "$1"
 do
   case $1 in
-    --basic) shift; BASIC=1; continue;;
-    --repo) shift; REPO_PATH=$1; shift; continue;;
+    --basic) shift; HVN_INSTALL_BASIC=y; continue;;
+    --repo) shift; HVN_REPO=$1; shift; continue;;
     *) usage;;
   esac
 done
 
-test -n "$REPO_PATH" || usage
-main $REPO_PATH $BASIC
+test -n "$HVN_REPO" || usage
+main $HVN_REPO $HVN_INSTALL_BASIC

--- a/scripts/func.sh
+++ b/scripts/func.sh
@@ -74,35 +74,36 @@ package_manager() {
 }
 
 # $1: package manager
-# $2: list of packages
+# $2-: list of packages
 package_install() {
-  msg "Installing system package dependencies..."
-  case ${1} in
+  local pkgmgr=$1; shift
+  msg "Installing system packages [$*] using [$pkgmgr]..."
+  case ${pkgmgr} in
     BREW )
       msg "Installing with homebrew..."
-      brew install ${2}
+      brew install $*
       ;;
     PORT )
       msg "Installing with port..."
-      port install ${2}
+      port install $*
       ;;
     APT )
       msg "Installing with apt-get..."
-      sudo apt-get install --no-upgrade -y ${2}
+      sudo apt-get install --no-upgrade -y $*
       ;;
     DNF )
       msg "Installing with DNF..."
-      sudo dnf install -yq ${2} # yum and dnf use same repos
+      sudo dnf install -yq $* # yum and dnf use same repos
       ;;
     YUM )
       msg "Installing with YUM..."
-      sudo yum install -yq ${2}
+      sudo yum install -yq $*
       ;;
     OTHER )
       warn "No package manager detected. You may need to install required packages manually."
       ;;
     * )
-      exit_err_report "setup.sh is not configured to handle ${1} manager."
+      exit_err_report "setup.sh is not configured to handle ${pkgmgr} manager."
   esac
 }
 

--- a/scripts/func.sh
+++ b/scripts/func.sh
@@ -63,6 +63,8 @@ package_manager() {
     package_manager="YUM"
   elif command -v apt-get >/dev/null 2>&1 ; then
     package_manager="APT"
+  elif command -v port >/dev/null 2>&1 ; then
+    package_manager="PORT"
   else
     package_manager="OTHER"
   fi
@@ -79,6 +81,10 @@ package_install() {
     BREW )
       msg "Installing with homebrew..."
       brew install ${2}
+      ;;
+    PORT )
+      msg "Installing with port..."
+      port install ${2}
       ;;
     APT )
       msg "Installing with apt-get..."

--- a/scripts/func.sh
+++ b/scripts/func.sh
@@ -71,6 +71,35 @@ package_manager() {
   return 0
 }
 
+# $1: package manager
+# $2: list of packages
+package_install() {
+  msg "Installing system package dependencies..."
+  case ${1} in
+    BREW )
+      msg "Installing with homebrew..."
+      brew install ${2}
+      ;;
+    APT )
+      msg "Installing with apt-get..."
+      sudo apt-get install --no-upgrade -y ${2}
+      ;;
+    DNF )
+      msg "Installing with DNF..."
+      sudo dnf install -yq ${2} # yum and dnf use same repos
+      ;;
+    YUM )
+      msg "Installing with YUM..."
+      sudo yum install -yq ${2}
+      ;;
+    OTHER )
+      warn "No package manager detected. You may need to install required packages manually."
+      ;;
+    * )
+      exit_err_report "setup.sh is not configured to handle ${1} manager."
+  esac
+}
+
 fix_path() {
   # $1 - path
   local return_path

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,6 +100,7 @@ package_list() {
       cmdpkg make make
       cmdpkg ctags exuberant-ctags
       cmdpkg par par
+      cmdpkg curl curl
       echo libcurl4-openssl-dev ;;
     YUM|DNF)
       cmdpkg make make
@@ -113,7 +114,7 @@ setup_tools() {
   local PACKAGE_MGR=$(package_manager)
   package_install ${PACKAGE_MGR} $(package_list ${PACKAGE_MGR})
 
-  local NOT_INSTALLED=$(check_exist ctags curl-config git make vim par)
+  local NOT_INSTALLED=$(check_exist ctags curl curl-config git make vim par)
   [ ! -z "${NOT_INSTALLED}" ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
 
   msg "Checking ctags' exuberance..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -114,7 +114,7 @@ setup_tools() {
   package_install ${PACKAGE_MGR} $(package_list ${PACKAGE_MGR})
 
   local NOT_INSTALLED=$(check_exist ctags curl-config git make vim par)
-  [ ! -z ${NOT_INSTALLED} ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
+  [ ! -z "${NOT_INSTALLED}" ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."
 
   msg "Checking ctags' exuberance..."
   local RETCODE

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,16 +75,41 @@ tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-ab
 EOF
 }
 
+# Print package name to install if command is not found
+# $1: command name
+# $2: package name
+cmdpkg() {
+  test -n "$(which $1)" || echo "$2"
+}
+
 # $1: package manager
 package_list() {
+  cmdpkg git git
+  cmdpkg vim vim
+
   case $1 in
-    BREW) echo "git homebrew/dupes/make vim ctags par" ;;
-    APT) echo "git make vim libcurl4-openssl-dev exuberant-ctags par" ;;
-    YUM|DNF) echo "git make vim ctags libcurl-devel zlib-devel powerline" ;;
+    BREW)
+      cmdpkg make homebrew/dupes/make
+      cmdpkg ctags ctags
+      cmdpkg par par ;;
+    PORT)
+      cmdpkg make gmake
+      cmdpkg ctags ctags
+      cmdpkg par par ;;
+    APT)
+      cmdpkg make make
+      cmdpkg ctags exuberant-ctags
+      cmdpkg par par
+      echo libcurl4-openssl-dev ;;
+    YUM|DNF)
+      cmdpkg make make
+      cmdpkg ctags ctags
+      echo "libcurl-devel zlib-devel powerline" ;;
   esac
 }
 
 setup_tools() {
+  # Installs _only if_ the command is not available
   local PACKAGE_MGR=$(package_manager)
   package_install ${PACKAGE_MGR} $(package_list ${PACKAGE_MGR})
 
@@ -94,7 +119,7 @@ setup_tools() {
   msg "Checking ctags' exuberance..."
   local RETCODE
   ctags --version | grep -q Exuberant ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Requires exuberant-ctags, not just ctags."
+  [ ${RETCODE} -ne 0 ] && exit_err "Requires exuberant-ctags, not just ctags. Please install and put it in your PATH."
 
   msg "Setting git to use fully-pathed vim for messages..."
   git config --global core.editor $(which vim)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,39 +75,18 @@ tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-ab
 EOF
 }
 
-setup_tools() {
-  local SYSTEM_TYPE=$(system_type)
-  local PACKAGE_MGR=$(package_manager)
-  local CONFIG_HOME=$(config_home)
-
-  local BREW_LIST="git homebrew/dupes/make vim ctags par"
-  local APT_LIST="git make vim libcurl4-openssl-dev exuberant-ctags par"
-  local YUM_LIST="git make vim ctags libcurl-devel zlib-devel powerline"
-
-  msg "Installing system package dependencies..."
-  case ${PACKAGE_MGR} in
-    BREW )
-      msg "Installing with homebrew..."
-      brew install ${BREW_LIST}
-      ;;
-    APT )
-      msg "Installing with apt-get..."
-      sudo apt-get install --no-upgrade -y ${APT_LIST}
-      ;;
-    DNF )
-      msg "Installing with DNF..."
-      sudo dnf install -yq ${YUM_LIST} # yum and dnf use same repos
-      ;;
-    YUM )
-      msg "Installing with YUM..."
-      sudo yum install -yq ${YUM_LIST}
-      ;;
-    OTHER )
-      warn "No package manager detected. You may need to install required packages manually."
-      ;;
-    * )
-      exit_err_report "setup.sh is not configured to handle ${PACKAGE_MGR} manager."
+# $1: package manager
+package_list() {
+  case $1 in
+    BREW) echo "git homebrew/dupes/make vim ctags par" ;;
+    APT) echo "git make vim libcurl4-openssl-dev exuberant-ctags par" ;;
+    YUM|DNF) echo "git make vim ctags libcurl-devel zlib-devel powerline" ;;
   esac
+}
+
+setup_tools() {
+  local PACKAGE_MGR=$(package_manager)
+  package_install ${PACKAGE_MGR} $(package_list ${PACKAGE_MGR})
 
   local NOT_INSTALLED=$(check_exist ctags curl-config git make vim par)
   [ ! -z ${NOT_INSTALLED} ] && exit_err "Installer requires '${NOT_INSTALLED}'. Please install and try again."


### PR DESCRIPTION
This pull request has a number of fixes described below. Fixes are in logically independent commits:

1) Support macports package manager (57d0691 & 	d04b877)
2) Pass advanced install options via env vars to enable passing the options even when bash executes the script via stdin.
3) Bug fix - bash syntax error when more than one space separated items are present in a list
4) install script fails when curl is not installed, so install it via the package manager. I did this only for 'apt' as mac has curl by default and I cannot test for 'yum'.