### PR TITLE
Ensure hindent 5 is installed by pinning version 5.2.1 (fixes #221)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,9 +56,13 @@ setup_haskell() {
   ln -sf ${STACK_BIN_PATH} ${HVN_DEST}/.stack-bin
 
   msg "Installing helper binaries..."
-  local STACK_LIST="ghc-mod hlint hasktags hscope pointfree pointful hoogle hindent apply-refact machines-directory-0.2.0.9 machines-io-0.2.0.13 codex-0.5.0.2"
+  local STACK_LIST="ghc-mod hlint hasktags hscope pointfree pointful hoogle apply-refact machines-directory-0.2.0.9 machines-io-0.2.0.13 codex-0.5.0.2"
   stack --resolver ${STACK_RESOLVER} install ${STACK_LIST} --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && exit_err "Binary installation failed with error ${RETCODE}."
+
+  # Install hindent 5 via pinned nightly
+  stack --resolver nightly-2016-12-28 install hindent --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "hindent installation failed with error ${RETCODE}."
 
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}


### PR DESCRIPTION
Temporarily pinning to `hindent` to Stackage nightly `nightly-2016-12-28` to install version 5.2.1.  This is only necessary until LTS `hindent` is 5.x.x.