### PR TITLE
Install sudo application for script usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN wget -q -O- https://s3.amazonaws.com/download.fpcomplete.com/debian/fpco.key
 RUN echo 'deb http://download.fpcomplete.com/debian/jessie stable main'| tee /etc/apt/sources.list.d/fpco.list
 RUN apt-get update \
  && apt-get install -y stack \
+ && apt-get install -y sudo \
  && apt-get clean
 
 # Haskell Vim setup


### PR DESCRIPTION
The script for installation onto linux requires the sudo application to exist when it executes. The base haskell image does not provide this command.