### PR TITLE
Get LTS-8.5 working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 - XDG_CONFIG_HOME=$HOME/.config
 
 script:
-- bash install.sh
+- bash install.sh --no-hoogle
 
 # Caching so the next build will be fast too.
 cache:

--- a/dependencies.cabal
+++ b/dependencies.cabal
@@ -1,0 +1,22 @@
+name:                dependencies
+version:             0.1.0.0
+synopsis:            helper binaries for vim
+homepage:            https://github.com/begriffs/haskell-vim-now
+license:             MIT
+author:              Joe Nelson
+maintainer:          cred+github@begriffs.com
+category:            Development
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  build-depends:       base >=4.9 && <4.10
+                     , apply-refact
+                     , codex
+                     , hasktags
+                     , hlint
+                     , hoogle
+                     , hscope
+                     , pointfree
+                     , pointful
+  default-language:    Haskell2010

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 PROGNAME=$(basename $0)
 DEFAULT_REPO="https://github.com/begriffs/haskell-vim-now.git"
+DEFAULT_GENERATE_HOOGLE_DB="y"
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
@@ -104,6 +105,7 @@ install() {
 do_setup() {
   local HVN_DEST=$1
   local BASIC_ONLY=$2
+  local GENERATE_HOOGLE_DB=$3
   local setup_path=${HVN_DEST}/scripts/setup.sh
 
   . $setup_path || { \
@@ -117,7 +119,7 @@ do_setup() {
 
   if test -z "$BASIC_ONLY"
   then
-    setup_haskell $HVN_DEST
+    setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB
   fi
 
   setup_done $HVN_DEST
@@ -126,20 +128,24 @@ do_setup() {
 main() {
   local REPO_PATH=$1
   local BASIC_ONLY=$2
+  local GENERATE_HOOGLE_DB=$3
   local HVN_DEST="$(config_home)/haskell-vim-now"
+  local HVN_DEPENDENCIES_DEST="$(config_home)/haskell-vim-now"
 
   install $REPO_PATH $HVN_DEST
-  do_setup $HVN_DEST $BASIC_ONLY
+  do_setup $HVN_DEST $BASIC_ONLY $GENERATE_HOOGLE_DB
 }
 
 function usage() {
-  echo "Usage: $PROGNAME [--basic] [--repo <path>]"
+  echo "Usage: $PROGNAME [--basic] [--repo <path>] [--no-hoogle]"
   echo ""
   echo "OPTIONS"
   echo "       --basic"
   echo "           Install only vim and plugins without haskell components."
   echo "       --repo <path>"
   echo "           Git repository to install from. The default is $DEFAULT_REPO."
+  echo "       --no-hoogle"
+  echo "           Disable Hoogle database generation. The default is $DEFAULT_GENERATE_HOOGLE_DB."
   exit 1
 }
 
@@ -156,16 +162,20 @@ check_boolean_var() {
 
 # command line args override env vars
 HVN_REPO=${HVN_REPO:=$DEFAULT_REPO}
+HVN_GENERATE_HOOGLE_DB=${HVN_GENERATE_HOOGLE_DB:=$DEFAULT_GENERATE_HOOGLE_DB}
+
 check_boolean_var HVN_INSTALL_BASIC
+check_boolean_var HVN_GENERATE_HOOGLE_DB
 
 while test -n "$1"
 do
   case $1 in
     --basic) shift; HVN_INSTALL_BASIC=y; continue;;
     --repo) shift; HVN_REPO=$1; shift; continue;;
+    --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=; continue;;
     *) usage;;
   esac
 done
 
 test -n "$HVN_REPO" || usage
-main $HVN_REPO $HVN_INSTALL_BASIC
+main $HVN_REPO $HVN_INSTALL_BASIC $HVN_GENERATE_HOOGLE_DB

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -97,8 +97,8 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  msg "Building Hoogle database..."
-  ${STACK_BIN_PATH}/hoogle generate
+  #msg "Building Hoogle database..."
+  #${STACK_BIN_PATH}/hoogle generate
 
   msg "Configuring codex to search in stack..."
   cat > $HOME/.codex <<EOF

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -76,7 +76,10 @@ setup_haskell() {
   [ ${RETCODE} -ne 0 ] && exit_err "Solving dependencies for helper binaries failed with error ${RETCODE}."
 
   # Clean up the comments and blank lines from stack.yaml.
-  sed -i.bak -e 's/^#.*$//' -e '/^$/d' stack.yaml
+  sed -i.bak1 -e 's/^#.*$//' -e '/^$/d' stack.yaml
+  
+  # Remove warning message from generated stack.yaml.
+  sed -i.bak2 -e '/user-message/,+3d' stack.yaml
 
   # Install all solved dependency versions for the helper binaries, while skipping local dependencies package and GHC.
   # Also skipping bogus 'invalid-cabal-flag-settings' dependency from base: https://github.com/commercialhaskell/stack/issues/2969

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,7 @@ stack_resolver() {
 
 setup_haskell() {
   local HVN_DEST=$1
+  local GENERATE_HOOGLE_DB=$2
   local RETCODE
 
   if ! check_exist stack >/dev/null ; then
@@ -97,8 +98,11 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  msg "Building Hoogle database..."
-  ${STACK_BIN_PATH}/hoogle generate
+  if test -n "$GENERATE_HOOGLE_DB"
+  then
+    msg "Building Hoogle database..."
+    ${STACK_BIN_PATH}/hoogle generate
+  fi
 
   msg "Configuring codex to search in stack..."
   cat > $HOME/.codex <<EOF

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -96,7 +96,7 @@ setup_haskell() {
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
   msg "Building Hoogle database..."
-  ${STACK_BIN_PATH}/hoogle data
+  ${STACK_BIN_PATH}/hoogle generate
 
   msg "Configuring codex to search in stack..."
   cat > $HOME/.codex <<EOF

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,7 +81,8 @@ setup_haskell() {
   sed -i.bak -e 's/^#.*$//' -e '/^$/d' stack.yaml
 
   # Install all solved dependency versions for the helper binaries, while skipping local dependencies package and GHC.
-  local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$")
+  # Also skipping bogus 'invalid-cabal-flag-settings' dependency from base: https://github.com/commercialhaskell/stack/issues/2969
+  local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$|^invalid-cabal-flag-settings-")
   for dep in $HELPER_BINARIES_DEPENDENCY_LIST
   do
     stack install $dep ; RETCODE=$?

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,13 +56,41 @@ setup_haskell() {
   ln -sf ${STACK_BIN_PATH} ${HVN_DEST}/.stack-bin
 
   msg "Installing helper binaries..."
-  local STACK_LIST="ghc-mod hlint hasktags hscope pointfree pointful hoogle apply-refact machines-directory-0.2.0.9 machines-io-0.2.0.13 codex-0.5.0.2"
-  stack --resolver ${STACK_RESOLVER} install ${STACK_LIST} --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Binary installation failed with error ${RETCODE}."
+  # Install ghc-mod via active stack resolver for maximum out-of-the-box compatibility.
+  stack --resolver ${STACK_RESOLVER} install ghc-mod --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Installing ghc-mod failed with error ${RETCODE}."
 
-  # Install hindent 5 via pinned nightly
-  stack --resolver nightly-2016-12-28 install hindent --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "hindent installation failed with error ${RETCODE}."
+  # Install hindent via pinned LTS to ensure we have version 5.
+  stack --resolver lts-8.6 install hindent --install-ghc --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Installing hindent failed with error ${RETCODE}."
+
+  # Stack dependency solving requires cabal to be on the PATH.
+  stack --resolver ${STACK_RESOLVER} install cabal-install --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Installing cabal-install failed with error ${RETCODE}."
+
+  # Create a temporary directory for helper binary dependency solving.
+  local HELPER_BINARIES_TEMP_DIR=$(mktemp -d)
+  cp ${HVN_DEST}/dependencies.cabal $HELPER_BINARIES_TEMP_DIR
+  pushd $HELPER_BINARIES_TEMP_DIR
+
+  # Solve the versions of all helper binaries listed in dependencies.cabal.
+  stack init --solver --install-ghc ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Solving dependencies for helper binaries failed with error ${RETCODE}."
+
+  # Clean up the comments and blank lines from stack.yaml.
+  sed -i.bak -e 's/^#.*$//' -e '/^$/d' stack.yaml
+
+  # Install all solved dependency versions for the helper binaries, while skipping local dependencies package and GHC.
+  local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$")
+  for dep in $HELPER_BINARIES_DEPENDENCY_LIST
+  do
+    stack install $dep ; RETCODE=$?
+    [ ${RETCODE} -ne 0 ] && exit_err "Installing helper binary dependency $dep failed with error ${RETCODE}."
+  done
+
+  # Clean up temporary directory.
+  popd
+  rm -rf $HELPER_BINARIES_TEMP_DIR
 
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,7 +82,7 @@ setup_haskell() {
 
   # Install all solved dependency versions for the helper binaries, while skipping local dependencies package and GHC.
   # Also skipping bogus 'invalid-cabal-flag-settings' dependency from base: https://github.com/commercialhaskell/stack/issues/2969
-  local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$|^invalid-cabal-flag-settings-")
+  local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$|^invalid-cabal-flag-settings-|^rts-")
   for dep in $HELPER_BINARIES_DEPENDENCY_LIST
   do
     stack install $dep ; RETCODE=$?

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -97,8 +97,8 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  #msg "Building Hoogle database..."
-  #${STACK_BIN_PATH}/hoogle generate
+  msg "Building Hoogle database..."
+  ${STACK_BIN_PATH}/hoogle generate
 
   msg "Configuring codex to search in stack..."
   cat > $HOME/.codex <<EOF

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,17 +56,15 @@ setup_haskell() {
   ln -sf ${STACK_BIN_PATH} ${HVN_DEST}/.stack-bin
 
   msg "Installing helper binaries..."
+  
   # Install ghc-mod via active stack resolver for maximum out-of-the-box compatibility.
-  stack --resolver ${STACK_RESOLVER} install ghc-mod --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Installing ghc-mod failed with error ${RETCODE}."
+  # Stack dependency solving requires cabal to be on the PATH.
+  stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning ; RETCODE=$?
+  [ ${RETCODE} -ne 0 ] && exit_err "Installing ghc-mod/cabal-install failed with error ${RETCODE}."
 
   # Install hindent via pinned LTS to ensure we have version 5.
   stack --resolver lts-8.6 install hindent --install-ghc --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && exit_err "Installing hindent failed with error ${RETCODE}."
-
-  # Stack dependency solving requires cabal to be on the PATH.
-  stack --resolver ${STACK_RESOLVER} install cabal-install --verbosity warning ; RETCODE=$?
-  [ ${RETCODE} -ne 0 ] && exit_err "Installing cabal-install failed with error ${RETCODE}."
 
   # Create a temporary directory for helper binary dependency solving.
   local HELPER_BINARIES_TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
Pin a few things to older LTS versions to make install from scratch less painful when using LTS-8.

~Move hindent to the main install list as it no longer requires a specific pinned nightly (Hindent 5 is in LTS-8.5).~

Call `hoogle generate` instead of `hoogle data`.