### PR TITLE
Fixing install.sh so that the BASIC_ONLY option does not always skip the haskell installation.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 
 PROGNAME=$(basename $0)
 DEFAULT_REPO="https://github.com/begriffs/haskell-vim-now.git"
-DEFAULT_GENERATE_HOOGLE_DB="y"
+DEFAULT_GENERATE_HOOGLE_DB=true
+DEFAULT_HVN_BASIC_ONLY=false
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
@@ -117,7 +118,7 @@ do_setup() {
   setup_tools
   setup_vim $HVN_DEST
 
-  if test -z "$BASIC_ONLY"
+  if "$BASIC_ONLY"
   then
     setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB
   fi
@@ -149,30 +150,17 @@ function usage() {
   exit 1
 }
 
-# $1: envvar
-check_boolean_var() {
-  local var=$(eval "echo \$$1")
-  if test -n "$var" -a "$var" != y
-  then
-    >&2 echo "Error: Boolean envvar [$1] can only be empty or 'y'"
-    exit 1
-  fi
-  echo "ENV: [$1=$var]"
-}
-
 # command line args override env vars
 HVN_REPO=${HVN_REPO:=$DEFAULT_REPO}
 HVN_GENERATE_HOOGLE_DB=${HVN_GENERATE_HOOGLE_DB:=$DEFAULT_GENERATE_HOOGLE_DB}
-
-check_boolean_var HVN_INSTALL_BASIC
-check_boolean_var HVN_GENERATE_HOOGLE_DB
+HVN_INSTALL_BASIC=${HVN_INSTALL_BASIC:=$DEFAULT_HVN_INSTALL_BASIC}
 
 while test -n "$1"
 do
   case $1 in
-    --basic) shift; HVN_INSTALL_BASIC=y; continue;;
+    --basic) shift; HVN_INSTALL_BASIC=false; continue;;
     --repo) shift; HVN_REPO=$1; shift; continue;;
-    --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=; continue;;
+    --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=false; continue;;
     *) usage;;
   esac
 done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,7 +98,7 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  if test -n "$GENERATE_HOOGLE_DB"
+  if "$GENERATE_HOOGLE_DB"
   then
     msg "Building Hoogle database..."
     ${STACK_BIN_PATH}/hoogle generate


### PR DESCRIPTION
Problem was that the 'boolean' values used before were actually just an empty variable and a 'y' character.  When the BASIC_ONLY parameter was passed into main, if --basic was not used then the variable was empty and so wasn't recognised as a parameter at all.

This meant that the 3rd parameter (the hoogle db one), got passed in as the second and as it was set to 'y' by default the haskell binary installation was skipped.

I just replaced these pseudo booleans with actual booleans and it is a little bit simpler now as a result.