### PR TITLE
Fixing install.sh so that the BASIC_ONLY option does not always skip the haskell installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 - XDG_CONFIG_HOME=$HOME/.config
 
 script:
-- bash install.sh --no-hoogle
+- bash install.sh --no-hoogle --dry-run
 
 # Caching so the next build will be fast too.
 cache:

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ PROGNAME=$(basename $0)
 DEFAULT_REPO="https://github.com/begriffs/haskell-vim-now.git"
 DEFAULT_GENERATE_HOOGLE_DB=true
 DEFAULT_HVN_FULL_INSTALL=true
+DEFAULT_DRY_RUN=false
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
@@ -107,6 +108,7 @@ do_setup() {
   local HVN_DEST=$1
   local FULL_INSTALL=$2
   local GENERATE_HOOGLE_DB=$3
+  local DRY_RUN=$4
   local setup_path=${HVN_DEST}/scripts/setup.sh
 
   . $setup_path || { \
@@ -120,7 +122,7 @@ do_setup() {
 
   if [ "$FULL_INSTALL" == true ]
   then
-    setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB
+    setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB $DRY_RUN
   fi
 
   setup_done $HVN_DEST
@@ -130,11 +132,12 @@ main() {
   local REPO_PATH=$1
   local FULL_INSTALL=$2
   local GENERATE_HOOGLE_DB=$3
+  local DRY_RUN=$4
   local HVN_DEST="$(config_home)/haskell-vim-now"
   local HVN_DEPENDENCIES_DEST="$(config_home)/haskell-vim-now"
 
   install $REPO_PATH $HVN_DEST
-  do_setup $HVN_DEST $FULL_INSTALL $GENERATE_HOOGLE_DB
+  do_setup $HVN_DEST $FULL_INSTALL $GENERATE_HOOGLE_DB $DRY_RUN
 }
 
 function usage() {
@@ -147,6 +150,8 @@ function usage() {
   echo "           Git repository to install from. The default is $DEFAULT_REPO."
   echo "       --no-hoogle"
   echo "           Disable Hoogle database generation. The default is $DEFAULT_GENERATE_HOOGLE_DB."
+  echo "       --dry-run"
+  echo "           Perform a dry run for the stack installs.  Primarily intended for testing."
   exit 1
 }
 
@@ -154,6 +159,7 @@ function usage() {
 HVN_REPO=${HVN_REPO:=$DEFAULT_REPO}
 HVN_GENERATE_HOOGLE_DB=${HVN_GENERATE_HOOGLE_DB:=$DEFAULT_GENERATE_HOOGLE_DB}
 HVN_FULL_INSTALL=${HVN_FULL_INSTALL:=$DEFAULT_HVN_FULL_INSTALL}
+HVN_DRY_RUN=${$HVN_DRY_RUN:=$DEFAULT_DRY_RUN}
 
 while test -n "$1"
 do
@@ -161,9 +167,10 @@ do
     --basic) shift; HVN_FULL_INSTALL=false; continue;;
     --repo) shift; HVN_REPO=$1; shift; continue;;
     --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=false; continue;;
+    --dry-run) shift; DRY_RUN=true; continue;;
     *) usage;;
   esac
 done
 
 test -n "$HVN_REPO" || usage
-main $HVN_REPO $HVN_FULL_INSTALL $HVN_GENERATE_HOOGLE_DB
+main $HVN_REPO $HVN_FULL_INSTALL $HVN_GENERATE_HOOGLE_DB $HVN_DRY_RUN

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ do_setup() {
   setup_tools
   setup_vim $HVN_DEST
 
-  if "$FULL_INSTALL"
+  if [ "$FULL_INSTALL" == true ]
   then
     setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB
   fi

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 
 PROGNAME=$(basename $0)
 DEFAULT_REPO="https://github.com/begriffs/haskell-vim-now.git"
-DEFAULT_GENERATE_HOOGLE_DB="y"
+DEFAULT_GENERATE_HOOGLE_DB=true
+DEFAULT_HVN_FULL_INSTALL=true
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
@@ -104,7 +105,7 @@ install() {
 
 do_setup() {
   local HVN_DEST=$1
-  local BASIC_ONLY=$2
+  local FULL_INSTALL=$2
   local GENERATE_HOOGLE_DB=$3
   local setup_path=${HVN_DEST}/scripts/setup.sh
 
@@ -117,7 +118,7 @@ do_setup() {
   setup_tools
   setup_vim $HVN_DEST
 
-  if test -z "$BASIC_ONLY"
+  if "$FULL_INSTALL"
   then
     setup_haskell $HVN_DEST $GENERATE_HOOGLE_DB
   fi
@@ -127,13 +128,13 @@ do_setup() {
 
 main() {
   local REPO_PATH=$1
-  local BASIC_ONLY=$2
+  local FULL_INSTALL=$2
   local GENERATE_HOOGLE_DB=$3
   local HVN_DEST="$(config_home)/haskell-vim-now"
   local HVN_DEPENDENCIES_DEST="$(config_home)/haskell-vim-now"
 
   install $REPO_PATH $HVN_DEST
-  do_setup $HVN_DEST $BASIC_ONLY $GENERATE_HOOGLE_DB
+  do_setup $HVN_DEST $FULL_INSTALL $GENERATE_HOOGLE_DB
 }
 
 function usage() {
@@ -149,33 +150,20 @@ function usage() {
   exit 1
 }
 
-# $1: envvar
-check_boolean_var() {
-  local var=$(eval "echo \$$1")
-  if test -n "$var" -a "$var" != y
-  then
-    >&2 echo "Error: Boolean envvar [$1] can only be empty or 'y'"
-    exit 1
-  fi
-  echo "ENV: [$1=$var]"
-}
-
 # command line args override env vars
 HVN_REPO=${HVN_REPO:=$DEFAULT_REPO}
 HVN_GENERATE_HOOGLE_DB=${HVN_GENERATE_HOOGLE_DB:=$DEFAULT_GENERATE_HOOGLE_DB}
-
-check_boolean_var HVN_INSTALL_BASIC
-check_boolean_var HVN_GENERATE_HOOGLE_DB
+HVN_FULL_INSTALL=${HVN_FULL_INSTALL:=$DEFAULT_HVN_FULL_INSTALL}
 
 while test -n "$1"
 do
   case $1 in
-    --basic) shift; HVN_INSTALL_BASIC=y; continue;;
+    --basic) shift; HVN_FULL_INSTALL=false; continue;;
     --repo) shift; HVN_REPO=$1; shift; continue;;
-    --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=; continue;;
+    --no-hoogle) shift; HVN_GENERATE_HOOGLE_DB=false; continue;;
     *) usage;;
   esac
 done
 
 test -n "$HVN_REPO" || usage
-main $HVN_REPO $HVN_INSTALL_BASIC $HVN_GENERATE_HOOGLE_DB
+main $HVN_REPO $HVN_FULL_INSTALL $HVN_GENERATE_HOOGLE_DB

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -92,20 +92,16 @@ setup_haskell() {
   # Also skipping bogus 'invalid-cabal-flag-settings' dependency from base: https://github.com/commercialhaskell/stack/issues/2969
   local HELPER_BINARIES_DEPENDENCY_LIST=$(stack list-dependencies --separator - | grep -vE "^dependencies-|^ghc-[0-9]\.[0-9]\.[0-9]$|^invalid-cabal-flag-settings-|^rts-")
 
-  if [ "$DRY_RUN" == false ]
-  then
-    for dep in $HELPER_BINARIES_DEPENDENCY_LIST
-    do
+  for dep in $HELPER_BINARIES_DEPENDENCY_LIST
+  do
+    if [ "$DRY_RUN" == false ]
+    then
       stack install $dep ; RETCODE=$?
-      [ ${RETCODE} -ne 0 ] && exit_err "Installing helper binary dependency $dep failed with error ${RETCODE}."
-    done
-  else
-    for dep in $HELPER_BINARIES_DEPENDENCY_LIST
-    do
+    else
       stack install $dep --dry-run ; RETCODE=$?
-      [ ${RETCODE} -ne 0 ] && exit_err "Installing helper binary dependency $dep failed with error ${RETCODE}."
-    done
-  fi
+    fi
+    [ ${RETCODE} -ne 0 ] && exit_err "Installing helper binary dependency $dep failed with error ${RETCODE}."
+  done
 
   # Clean up temporary directory.
   popd

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,12 +61,7 @@ setup_haskell() {
   
   # Install ghc-mod via active stack resolver for maximum out-of-the-box compatibility.
   # Stack dependency solving requires cabal to be on the PATH.
-  if [ "$DRY_RUN" == false ]
-  then
-    stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning ; RETCODE=$?
-  else
-    stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning --dry-run ; RETCODE=$?
-  fi
+  stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning ; RETCODE=$?
   [ ${RETCODE} -ne 0 ] && exit_err "Installing ghc-mod/cabal-install failed with error ${RETCODE}."
 
   # Install hindent via pinned LTS to ensure we have version 5.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,7 +98,7 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  if "$GENERATE_HOOGLE_DB"
+  if [ "$GENERATE_HOOGLE_DB" == true ]
   then
     msg "Building Hoogle database..."
     ${STACK_BIN_PATH}/hoogle generate

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,7 +98,7 @@ setup_haskell() {
   msg "Installing git-hscope..."
   cp ${HVN_DEST}/git-hscope ${STACK_BIN_PATH}
 
-  if test -n "$GENERATE_HOOGLE_DB"
+  if "$GENERATE_HOOGLE_DB"
   then
     msg "Building Hoogle database..."
     ${STACK_BIN_PATH}/hoogle generate

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,11 +61,21 @@ setup_haskell() {
   
   # Install ghc-mod via active stack resolver for maximum out-of-the-box compatibility.
   # Stack dependency solving requires cabal to be on the PATH.
-  stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning ; RETCODE=$?
+  if [ "$DRY_RUN" == false ]
+  then
+    stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning ; RETCODE=$?
+  else
+    stack --resolver ${STACK_RESOLVER} install ghc-mod cabal-install --verbosity warning --dry-run ; RETCODE=$?
+  fi
   [ ${RETCODE} -ne 0 ] && exit_err "Installing ghc-mod/cabal-install failed with error ${RETCODE}."
 
   # Install hindent via pinned LTS to ensure we have version 5.
-  stack --resolver lts-8.6 install hindent --install-ghc --verbosity warning ; RETCODE=$?
+  if [ "$DRY_RUN" == false ]
+  then
+    stack --resolver lts-8.6 install hindent --install-ghc --verbosity warning ; RETCODE=$?
+  else
+    stack --resolver lts-8.6 install hindent --install-ghc --verbosity warning --dry-run ; RETCODE=$?
+  fi
   [ ${RETCODE} -ne 0 ] && exit_err "Installing hindent failed with error ${RETCODE}."
 
   # Create a temporary directory for helper binary dependency solving.


### PR DESCRIPTION
Problem was that the 'boolean' values used before were actually just an empty variable and a 'y' character. When the BASIC_ONLY parameter was passed into main, if --basic was not used then the variable was empty and so wasn't recognised as a parameter at all.

This meant that the 3rd parameter (the hoogle db one), got passed in as the second and as it was set to 'y' by default the Haskell binary installation was skipped.

I just replaced these pseudo booleans with actual booleans and it is a little bit simpler now as a result.  Then renamed the variables so that the logic made a little more sense.