### PR TITLE
Fedora requires installing 'par'

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -155,7 +155,7 @@ package_list() {
     YUM|DNF)
       cmdpkg make make
       cmdpkg ctags ctags
-      echo "libcurl-devel zlib-devel powerline" ;;
+      echo "libcurl-devel zlib-devel powerline par" ;;
   esac
 }
 


### PR DESCRIPTION
Also, I suggest detecting if neovim is installed and if so then skip installing vim.