### PR TITLE
Fixes #258: Need to check for minimum required stack version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,11 @@ do_setup() {
       exit 1
     fi
 
+    local STACK_VER=$(stack --version | sed 's/^Version \([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+    if ! verlte '1.4.0' ${STACK_VER} ; then
+      exit_err "Detected stack version \"${STACK_VER}\", however version 1.4.0 or later is required."
+    fi
+
     stack $setup_haskell_path $ARG_NO_HOOGLE_DB $ARG_NO_HELPER_BINS ; RETCODE=$?
     [ ${RETCODE} -ne 0 ] && exit_err "setup_haskell.hs failed with error ${RETCODE}."
   fi


### PR DESCRIPTION
Check for a required minimum `stack` version of 1.4.0.