### PR TITLE
Temporarily rely on lts-7.24 for cabal-install and the helper binaries

### DIFF
--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -144,8 +144,7 @@ setupHaskell = do
               "dependencies.cabal"
               (toStrict helperDependenciesCabalText)
           Turtle.stdout (Turtle.input "dependencies.cabal")
-          let solverCommand = "stack init --solver --resolver "
-                              <> stackResolver
+          let solverCommand = "stack init --solver --resolver lts-7.24"
                               <> " --install-ghc"
           -- XXX for best results we should solve and install each one of them
           -- independently rather than solving them together. It becomes more
@@ -173,9 +172,9 @@ setupHaskell = do
           -- XXX I could not figure out how to keep the ">" sign unescaped in
           -- mustache, so had to treat this especially. If we can do that then
           -- we can push this as well in helperDependencies.
-          stackInstall stackResolver "hscope" True
+          stackInstall "lts-7.24" "hscope" True
           forM_ (map (head . Text.words) helperDependencies) $
-            \dep -> stackInstall stackResolver dep True
+            \dep -> stackInstall "lts-7.24" dep True
           -- XXX we should remove the temporary dir after installing to reclaim
           -- unnecessary space.
         msg "Installing git-hscope..."

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -133,7 +133,7 @@ setupHaskell = do
           -- out-of-the-box compatibility.
           stackInstall stackResolver "ghc-mod" False
           -- Stack dependency solving requires cabal to be on the PATH.
-          stackInstall stackResolver "cabal-install" True
+          stackInstall "lts-7.24" "cabal-install" True
           -- Install hindent via pinned LTS to ensure we have version 5.
           stackInstall "lts-8.14" "hindent" True
           let helperDependenciesCabalText =

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -240,7 +240,7 @@ stackInstall resolver package exitOnFailure = do
       case exitOnFailure of
         True -> Turtle.exit (Turtle.ExitFailure 1)
         False -> handleFailure package where
-          handleFailure :: Text -> m ()
+          handleFailure :: (MonadIO m) => Text -> m ()
           handleFailure "ghc-mod" =
             msg $ "To install \"ghc-mod\" manually, see here: " <>
                   "https://github.com/DanielG/ghc-mod/issues/900"

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -238,7 +238,7 @@ stackInstall resolver package exitOnFailure = do
         "\"" <> installCommand <> "\" failed with error " <>
         (Text.pack . show $ retCode)
       case exitOnFailure of
-        True -> Turtle.ext (Turtle.ExitFailure 1)
+        True -> Turtle.exit (Turtle.ExitFailure 1)
         False -> handleFailure package where
           handleFailure :: Text -> m ()
           handleFailure "ghc-mod" =

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -272,7 +272,7 @@ cabal-version:       >=1.10
 
 library
 -- hscope 0.4 does not compile with most resolvers so use newer
-  build-depends:       base >=4.9 && <4.10
+  build-depends:       base >=4.9 && <4.11
                      , hscope > 0.4
 {{#dependencies}}
                      , {{.}}


### PR DESCRIPTION
This PR gets the installer working again, per discussion over in #282.

Relying on lts-7.24 is a bit of a hack, but would rather get the installer working again now and we come up with a better solution later.

Special thanks to @bidhan-a!  @bidhan-a added support to selectively not bail out of the whole installer if a `stackInstall` fails and added a link for users to get more info on installing `ghc-mod` after the fact.