### PR TITLE
an attempt to make haskell-vim-now usable with newer GHC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      echo 'deb http://download.fpcomplete.com/ubuntu xenial main'|sudo tee /etc/apt/sources.list.d/fpco.list
+      curl -sSL https://get.haskellstack.org/ | sh
+      stack --version
       sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442
       sudo add-apt-repository ppa:nmi/vim-snapshots -y
       sudo apt-get -qq update -y
-      sudo apt-get install vim stack ctags -y
+      sudo apt-get install vim ctags -y
     fi
   # emulating upgrade procedure (due to install.sh cloning from begriffs/master)
   - cp -r $TRAVIS_BUILD_DIR $XDG_CONFIG_HOME/

--- a/.vimrc
+++ b/.vimrc
@@ -119,9 +119,7 @@ Plug 'neovimhaskell/haskell-vim', { 'for': 'haskell' }
 Plug 'enomsg/vim-haskellConcealPlus', { 'for': 'haskell' }
 Plug 'neoclide/coc.nvim', { 'do': { -> coc#util#install() } }
 Plug 'Twinside/vim-hoogle', { 'for': 'haskell' }
-" http://marco-lopes.com/articles/Vim-and-Haskell-in-2019/
-" Turns out you can get coc.vim to do refactoring for you without the need for an extra plugin.
-" Plug 'mpickering/hlint-refactor-vim', { 'for': 'haskell' }
+Plug 'mpickering/hlint-refactor-vim', { 'for': 'haskell' }
 
 " Colorscheme
 Plug 'vim-scripts/wombat256.vim'

--- a/.vimrc
+++ b/.vimrc
@@ -509,16 +509,6 @@ map <Leader>a<bar> :Align <bar><CR>
 map <leader>ap :Align
 " }}}
 
-" Tags {{{
-
-map <leader>tt :TagbarToggle<CR>
-
-set tags=tags;/
-set cst
-set csverb
-
-" }}}
-
 " Git {{{
 
 let g:extradite_width = 60

--- a/.vimrc
+++ b/.vimrc
@@ -117,10 +117,11 @@ Plug 'christoomey/vim-tmux-navigator'
 " Haskell
 Plug 'neovimhaskell/haskell-vim', { 'for': 'haskell' }
 Plug 'enomsg/vim-haskellConcealPlus', { 'for': 'haskell' }
-Plug 'eagletmt/ghcmod-vim', { 'for': 'haskell' }
-Plug 'eagletmt/neco-ghc', { 'for': 'haskell' }
+Plug 'neoclide/coc.nvim', { 'do': { -> coc#util#install() } }
 Plug 'Twinside/vim-hoogle', { 'for': 'haskell' }
-Plug 'mpickering/hlint-refactor-vim', { 'for': 'haskell' }
+" http://marco-lopes.com/articles/Vim-and-Haskell-in-2019/
+" Turns out you can get coc.vim to do refactoring for you without the need for an extra plugin.
+" Plug 'mpickering/hlint-refactor-vim', { 'for': 'haskell' }
 
 " Colorscheme
 Plug 'vim-scripts/wombat256.vim'

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@
 
 <br />
 
-### Notice: this project is broken
-
-Due to the fragile Haskell ecosystem, most notably ghc-mod, this vim configuration no longer works. You'll just spend lots of time waiting for its helper binaries to build, and be left with used disk space and regret.
-
-<hr />
-
-### Original readme:
-
 In less than **ten minutes** your Vim will transform into a beautiful
 Haskell paradise.  (Don't worry, it backs up your original
 configuration to `~/.config/haskell-vim-now/backup/.vimrc.yearmonthdate_time`.) It also builds all necessary support binaries

--- a/README.md
+++ b/README.md
@@ -209,19 +209,6 @@ selections to it. This works well for evaluating things in GHCI.
 </tbody>
 </table>
 
-### Conversions
-
-<table>
-<tbody>
-  <tr>
-    <td>,h.</td><td>Transform visual selection to pointfree style</td>
-  </tr>
-  <tr>
-    <td>,h&gt;</td><td>Transform visual selection to pointed style</td>
-  </tr>
-</tbody>
-</table>
-
 ### Buffers
 
 <table>

--- a/README.md
+++ b/README.md
@@ -190,25 +190,6 @@ selections to it. This works well for evaluating things in GHCI.
 </tbody>
 </table>
 
-### Tags
-
-<table>
-<tbody>
-  <tr>
-    <td>,tg</td><td>Generate tags with codex</td>
-  </tr>
-  <tr>
-    <td>,tt</td><td>Open/close the tag bar</td>
-  </tr>
-  <tr>
-    <td>C-]</td><td>Jump to definition of symbol (codex + hasktags)</td><td>Note: You must generate the tags for your project (with <code>,tg</code>) prior to using the jump command.</td> 
-  </tr>
-  <tr>
-    <td>C-\</td><td>Show uses of symbol (hscope)</td>
-  </tr>
-</tbody>
-</table>
-
 ### Buffers
 
 <table>

--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ them.
     <td>&lt;C-space&gt;</td><td>Autocomplete with symbols in your Cabal sandbox</td>
   </tr>
   <tr>
-    <td>,ht</td><td>Show type of expression under cursor</td>
-  </tr>
-  <tr>
-    <td>,hT</td><td>Insert type of expression into previous line</td>
-  </tr>
-  <tr>
     <td>,hr</td><td>Apply one refactoring hint at cursor position</td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 In less than **ten minutes** your Vim will transform into a beautiful
 Haskell paradise.  (Don't worry, it backs up your original
 configuration to `~/.config/haskell-vim-now/backup/.vimrc.yearmonthdate_time`.) It also builds all necessary support binaries
-including `codex`, `hscope`, `ghc-mod`, `hasktags`, `hoogle` and more.
+including `ghcide`, `hlint`, `hoogle` and more.
 
 No more wading through plugins trying to make them all work together.
 In ten minutes you will have a fully functional Vim that looks great

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -205,6 +205,7 @@ setupHaskell = do
         -- homePath <- Turtle.home
         -- liftIO
         --   (Turtle.writeTextFile (homePath </> ".codex") (toStrict codexText))
+        liftIO $ Turtle.writeTextFile (hvnCfgDest </> ".vim/coc-settings.json") cocSettings
 
 stackResolverText :: (MonadIO m) => FilePath -> m Text
 stackResolverText stackYamlPath = do

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -24,10 +24,9 @@ import qualified Control.Foldl as Foldl
 import Control.Monad (mfilter, unless, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader, ask, runReaderT)
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Data.Aeson ((.=), object)
 import Data.Foldable (forM_)
-import Data.Maybe (isJust, listToMaybe)
+import Data.Maybe (listToMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Text as Text
 import Data.Text (Text)

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -6,6 +6,7 @@
   --package ansi-terminal
   --package foldl
   --package mtl
+  --package raw-strings-qq
   --package stache
   --package system-filepath
   --package text
@@ -40,6 +41,7 @@ import qualified System.IO
 import System.Info (os)
 import Text.Mustache (Template, renderMustache)
 import Text.Mustache.Compile.TH (mustache)
+import Text.RawString.QQ (r)
 import qualified Turtle
 
 data HvnConfig = HvnConfig
@@ -351,3 +353,28 @@ filePathToText = Turtle.format Turtle.fp
 
 textToFilePath :: Text -> FilePath
 textToFilePath = FS.fromText
+
+cocSettings :: Text
+cocSettings = [r|{
+  "languageserver": {
+    "haskell": {
+      "command": "ghcide",
+      "args": [
+        "--lsp"
+      ],
+      "rootPatterns": [
+        ".stack.yaml",
+        ".hie-bios",
+        "BUILD.bazel",
+        "cabal.config",
+        "package.yaml"
+      ],
+      "filetypes": [
+        "hs",
+        "lhs",
+        "haskell"
+      ]
+    }
+  }
+}
+|]

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -372,11 +372,11 @@ CompilerSet errorformat+=%-GCompleted\ %s
 " exclude empty or whitespace-only lines
 CompilerSet errorformat+=%-G\\s%#
 CompilerSet errorformat+=%EMessage:%\\s%#%>
-CompilerSet errorformat+=%C%\\s%#ESC[%\\d%#;%\\d%#m%f:%l:%c:%m
+CompilerSet errorformat+=%C%\\s%#%f:%l:%c:%\\s%#error:%\\s%#%>
 CompilerSet errorformat+=%C%m
 CompilerSet errorformat+=%ZCompleted%m
 
-setlocal makeprg=ghcide\ %
+setlocal makeprg=ghcide\ %\ 2>&1\ \\\|\ sed\ 's/\\x1B\\[[0-9;]*m//g'
 |]
 
 gitCloneInstall :: MonadIO m => HelperRepository -> HelperTool -> Maybe Resolver -> m ()

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -259,13 +259,6 @@ library
   default-language:    Haskell2010
 |]
 
-codexTemplate :: Template
-codexTemplate = [mustache|hackagePath: {{stackHackageIndicesDir}}
-tagsFileHeader: false
-tagsFileSorted: false
-tagsCmd: hasktags --extendedctag --ignore-close-implementation --ctags --tags-absolute --output="$TAGS" "$SOURCES"
-|]
-
 msg :: (MonadIO m) => Text -> m ()
 msg =
   consoleLog

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -134,10 +134,6 @@ setupHaskell = do
           -- Install ghcide from source for maximum
           -- out-of-the-box compatibility.
           installGhcide
-          --FIXME can we use codex, hasktags without hscope,
-          -- which is broken https://github.com/bosu/hscope/issues/11
-          -- installHasktags (Just stackResolver)
-          -- installCodex (Just stackResolver)
           -- Stack dependency solving requires cabal to be on the PATH.
           stackInstall stackResolver "cabal-install" True
           -- Install hindent via default LTS
@@ -178,17 +174,10 @@ setupHaskell = do
           -- XXX I could not figure out how to keep the ">" sign unescaped in
           -- mustache, so had to treat this especially. If we can do that then
           -- we can push this as well in helperDependencies.
-          -- stackInstall "lts-7.24" "hscope" True
           forM_ (map (head . Text.words) helperDependencies) $
             \dep -> stackInstall stackResolver dep True
           -- XXX we should remove the temporary dir after installing to reclaim
           -- unnecessary space.
-        -- msg "Installing git-hscope..."
-        -- -- TODO: The 'git-hscope' file won't do much good on Windows as it
-        -- -- is a bash script.
-        -- Turtle.cp
-        --   (hvnCfgDest </> "git-hscope")
-        --   (textToFilePath stackBinPath </> "git-hscope")
         when hvnCfgHoogleDb $ do
           msg "Building Hoogle database..."
           Turtle.sh
@@ -196,15 +185,6 @@ setupHaskell = do
                (filePathToText (textToFilePath stackBinPath </> "hoogle") <>
                 " generate")
                empty)
-        -- msg "Configuring codex to search in stack..."
-        -- let codexText =
-        --       renderMustache codexTemplate $
-        --       object [ "stackHackageIndicesDir" .=
-        --                  filePathToText (textToFilePath stackGlobalDir
-        --                    </> "indices" </> "Hackage") ]
-        -- homePath <- Turtle.home
-        -- liftIO
-        --   (Turtle.writeTextFile (homePath </> ".codex") (toStrict codexText))
         liftIO $ Turtle.writeTextFile (hvnCfgDest </> ".vim/coc-settings.json") cocSettings
 
 stackResolverText :: (MonadIO m) => FilePath -> m Text
@@ -253,13 +233,8 @@ stackInstall resolver package exitOnFailure = do
 helperDependencies :: [Text]
 helperDependencies =
   [ "apply-refact"
-  -- stack can't resolve dependency http-client for codex
-  -- , "codex"
-  -- , "hasktags"
   , "hlint"
   , "hoogle"
-  -- , "pointfree"
-  -- , "pointful"
   ]
 
 helperDependenciesCabalTemplate :: Template
@@ -364,13 +339,6 @@ hvn = "haskell-vim-now"
 type HelperRepository = Text
 type HelperTool = Text
 type Resolver = Text
-
-installCodex :: MonadIO m => Maybe Resolver -> m ()
--- https://github.com/aloiscochard/codex.git doesn't support lts-14.X yet
-installCodex = gitCloneInstall "--branch=stack-lts-14.12 git@github.com:p-alik/codex.git" "codex"
-
-installHasktags :: MonadIO m =>  Maybe Resolver -> m ()
-installHasktags = gitCloneInstall "https://github.com/MarcWeber/hasktags.git" "hasktags"
 
 installGhcide :: MonadIO m => m ()
 installGhcide = gitCloneInstall "https://github.com/digital-asset/ghcide.git" "ghcide" Nothing

--- a/scripts/setup_haskell.hs
+++ b/scripts/setup_haskell.hs
@@ -359,7 +359,23 @@ installGhcide = do
       let d' = d <> "compiler"
       mkdir' d'
       toFile (d' </> "ghcide.vim") [r|
-setlocal errorformat=%f:%l:%c:\ %t%*[a-zA-Z]:\ %m
+CompilerSet errorformat=%-Gghcide\ %s
+CompilerSet errorformat+=%-GReport\ bugs\ at\ %s
+CompilerSet errorformat+=%-GStep\ %s
+CompilerSet errorformat+=%-GFound\ %s
+CompilerSet errorformat+=%-GCradle\ %s
+CompilerSet errorformat+=%-GRange:\ %s
+CompilerSet errorformat+=%-GFile:\ %s
+CompilerSet errorformat+=%-GSource:\ %s
+CompilerSet errorformat+=%-GSeverity:\ %s
+CompilerSet errorformat+=%-GCompleted\ %s
+" exclude empty or whitespace-only lines
+CompilerSet errorformat+=%-G\\s%#
+CompilerSet errorformat+=%EMessage:%\\s%#%>
+CompilerSet errorformat+=%C%\\s%#ESC[%\\d%#;%\\d%#m%f:%l:%c:%m
+CompilerSet errorformat+=%C%m
+CompilerSet errorformat+=%ZCompleted%m
+
 setlocal makeprg=ghcide\ %
 |]
 

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -136,10 +136,6 @@ let g:necoghc_enable_detailed_browse = 1
 " Resolve ghcmod base directory
 au FileType haskell let g:ghcmod_use_basedir = getcwd()
 
-" Type of expression under cursor
-nmap <silent> <leader>ht :GhcModType<CR>
-" Insert type of expression under cursor
-nmap <silent> <leader>hT :GhcModTypeInsert<CR>
 " GHC errors and warnings
 nmap <silent> <leader>hc :Neomake ghcmod<CR>
 

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -17,62 +17,62 @@ let hscoptions="𝐒𝐓𝐄𝐌xRtB𝔻w"
 
 " }}}
 
-" Tags {{{
-
-set tags+=codex.tags;/
-
-let g:tagbar_type_haskell = {
-    \ 'ctagsbin'  : 'hasktags',
-    \ 'ctagsargs' : '-x -c -o-',
-    \ 'kinds'     : [
-        \  'm:modules:0:1',
-        \  'd:data: 0:1',
-        \  'd_gadt: data gadt:0:1',
-        \  't:type names:0:1',
-        \  'nt:new types:0:1',
-        \  'c:classes:0:1',
-        \  'cons:constructors:1:1',
-        \  'c_gadt:constructor gadt:1:1',
-        \  'c_a:constructor accessors:1:1',
-        \  'ft:function types:1:1',
-        \  'fi:function implementations:0:1',
-        \  'o:others:0:1'
-    \ ],
-    \ 'sro'        : '.',
-    \ 'kind2scope' : {
-        \ 'm' : 'module',
-        \ 'c' : 'class',
-        \ 'd' : 'data',
-        \ 't' : 'type'
-    \ },
-    \ 'scope2kind' : {
-        \ 'module' : 'm',
-        \ 'class'  : 'c',
-        \ 'data'   : 'd',
-        \ 'type'   : 't'
-    \ }
-\ }
-
-" Generate haskell tags with codex and hscope
-map <leader>tg :!codex update --force<CR>:call system("git-hscope -X TemplateHaskell")<CR><CR>:call LoadHscope()<CR>
-
-set csprg=hscope
-set csto=1 " search codex tags first
-
-nnoremap <silent> <C-\> :cs find c <C-R>=expand("<cword>")<CR><CR>
-" Automatically make cscope connections
-function! LoadHscope()
-  let db = findfile("hscope.out", ".;")
-  if (!empty(db))
-    let path = strpart(db, 0, match(db, "/hscope.out$"))
-    set nocscopeverbose " suppress 'duplicate connection' error
-    exe "cs add " . db . " " . path
-    set cscopeverbose
-  endif
-endfunction
-au BufEnter /*.hs call LoadHscope()
-
-" }}}
+"" Tags {{{
+"
+"set tags+=codex.tags;/
+"
+"let g:tagbar_type_haskell = {
+"    \ 'ctagsbin'  : 'hasktags',
+"    \ 'ctagsargs' : '-x -c -o-',
+"    \ 'kinds'     : [
+"        \  'm:modules:0:1',
+"        \  'd:data: 0:1',
+"        \  'd_gadt: data gadt:0:1',
+"        \  't:type names:0:1',
+"        \  'nt:new types:0:1',
+"        \  'c:classes:0:1',
+"        \  'cons:constructors:1:1',
+"        \  'c_gadt:constructor gadt:1:1',
+"        \  'c_a:constructor accessors:1:1',
+"        \  'ft:function types:1:1',
+"        \  'fi:function implementations:0:1',
+"        \  'o:others:0:1'
+"    \ ],
+"    \ 'sro'        : '.',
+"    \ 'kind2scope' : {
+"        \ 'm' : 'module',
+"        \ 'c' : 'class',
+"        \ 'd' : 'data',
+"        \ 't' : 'type'
+"    \ },
+"    \ 'scope2kind' : {
+"        \ 'module' : 'm',
+"        \ 'class'  : 'c',
+"        \ 'data'   : 'd',
+"        \ 'type'   : 't'
+"    \ }
+"\ }
+"
+"" Generate haskell tags with codex and hscope
+"map <leader>tg :!codex update --force<CR>:call system("git-hscope -X TemplateHaskell")<CR><CR>:call LoadHscope()<CR>
+"
+"set csprg=hscope
+"set csto=1 " search codex tags first
+"
+"nnoremap <silent> <C-\> :cs find c <C-R>=expand("<cword>")<CR><CR>
+"" Automatically make cscope connections
+"function! LoadHscope()
+"  let db = findfile("hscope.out", ".;")
+"  if (!empty(db))
+"    let path = strpart(db, 0, match(db, "/hscope.out$"))
+"    set nocscopeverbose " suppress 'duplicate connection' error
+"    exe "cs add " . db . " " . path
+"    set cscopeverbose
+"  endif
+"endfunction
+"au BufEnter /*.hs call LoadHscope()
+"
+"" }}}
 
 " Hoogle {{{
 " Hoogle the word under the cursor

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -17,63 +17,6 @@ let hscoptions="𝐒𝐓𝐄𝐌xRtB𝔻w"
 
 " }}}
 
-"" Tags {{{
-"
-"set tags+=codex.tags;/
-"
-"let g:tagbar_type_haskell = {
-"    \ 'ctagsbin'  : 'hasktags',
-"    \ 'ctagsargs' : '-x -c -o-',
-"    \ 'kinds'     : [
-"        \  'm:modules:0:1',
-"        \  'd:data: 0:1',
-"        \  'd_gadt: data gadt:0:1',
-"        \  't:type names:0:1',
-"        \  'nt:new types:0:1',
-"        \  'c:classes:0:1',
-"        \  'cons:constructors:1:1',
-"        \  'c_gadt:constructor gadt:1:1',
-"        \  'c_a:constructor accessors:1:1',
-"        \  'ft:function types:1:1',
-"        \  'fi:function implementations:0:1',
-"        \  'o:others:0:1'
-"    \ ],
-"    \ 'sro'        : '.',
-"    \ 'kind2scope' : {
-"        \ 'm' : 'module',
-"        \ 'c' : 'class',
-"        \ 'd' : 'data',
-"        \ 't' : 'type'
-"    \ },
-"    \ 'scope2kind' : {
-"        \ 'module' : 'm',
-"        \ 'class'  : 'c',
-"        \ 'data'   : 'd',
-"        \ 'type'   : 't'
-"    \ }
-"\ }
-"
-"" Generate haskell tags with codex and hscope
-"map <leader>tg :!codex update --force<CR>:call system("git-hscope -X TemplateHaskell")<CR><CR>:call LoadHscope()<CR>
-"
-"set csprg=hscope
-"set csto=1 " search codex tags first
-"
-"nnoremap <silent> <C-\> :cs find c <C-R>=expand("<cword>")<CR><CR>
-"" Automatically make cscope connections
-"function! LoadHscope()
-"  let db = findfile("hscope.out", ".;")
-"  if (!empty(db))
-"    let path = strpart(db, 0, match(db, "/hscope.out$"))
-"    set nocscopeverbose " suppress 'duplicate connection' error
-"    exe "cs add " . db . " " . path
-"    set cscopeverbose
-"  endif
-"endfunction
-"au BufEnter /*.hs call LoadHscope()
-"
-"" }}}
-
 " Hoogle {{{
 " Hoogle the word under the cursor
 nnoremap <silent> <leader>hh :Hoogle<CR>

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -153,17 +153,3 @@ function! GhcideCompile()
 endfunction
 
 " }}}
-
-" Point Conversion {{{
-
-function! Pointfree()
-  call setline('.', split(system('pointfree '.shellescape(join(getline(a:firstline, a:lastline), "\n"))), "\n"))
-endfunction
-vnoremap <silent> <leader>h. :call Pointfree()<CR>
-
-function! Pointful()
-  call setline('.', split(system('pointful '.shellescape(join(getline(a:firstline, a:lastline), "\n"))), "\n"))
-endfunction
-vnoremap <silent> <leader>h> :call Pointful()<CR>
-
-" }}}

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -73,26 +73,7 @@ autocmd BufRead *
 " Haskell Lint
 nmap <silent> <leader>hl :Neomake hlint<CR>
 
-" " GHC errors and warnings
-nnoremap <silent> <leader>hc :call GhcideCompile()<cr>
-if !exists("g:ghcide_command")
-    let g:ghcide_command = "ghcide"
-endif
-
-function! GhcideCompile()
-  " silent !clear
-  " execute "!" . g:ghcide_command . " " . bufname("%")
-  " Get the bytecode.
-  let bytecode = system(g:ghcide_command . " " . bufname("%") . " 2>&1")
-
-  " Open a new split and set it up.
-  vsplit __Ghcide_Bytecode__
-  normal! ggdG
-  setlocal filetype=potionbytecode
-  setlocal buftype=nofile
-
-  " Insert the bytecode.
-  call append(0, split(bytecode, '\v\n'))
-endfunction
+" GHC errors and warnings
+noremap <silent> <leader>hc :make<CR><CR>:copen<CR>
 
 " }}}

--- a/vimrc.haskell
+++ b/vimrc.haskell
@@ -109,38 +109,12 @@ augroup END
 
 "Completion, Syntax check, Lint & Refactor {{{
 
-augroup haskell
-  autocmd!
-  autocmd FileType haskell map <silent> <leader><cr> :noh<cr>:GhcModTypeClear<cr>
-  autocmd FileType haskell setlocal omnifunc=necoghc#omnifunc
-augroup END
-
-" Provide (neco-ghc) omnicompletion
-if has("gui_running")
-  imap <c-space> <c-r>=SuperTabAlternateCompletion("\<lt>c-x>\<lt>c-o>")<cr>
-else " no gui
-  if has("unix")
-    inoremap <Nul> <c-r>=SuperTabAlternateCompletion("\<lt>c-x>\<lt>c-o>")<cr>
-  endif
-endif
-
 " Disable hlint-refactor-vim's default keybindings
 let g:hlintRefactor#disableDefaultKeybindings = 1
 
 " hlint-refactor-vim keybindings
 map <silent> <leader>hr :call ApplyOneSuggestion()<CR>
 map <silent> <leader>hR :call ApplyAllSuggestions()<CR>
-
-" Show types in completion suggestions
-let g:necoghc_enable_detailed_browse = 1
-" Resolve ghcmod base directory
-au FileType haskell let g:ghcmod_use_basedir = getcwd()
-
-" GHC errors and warnings
-nmap <silent> <leader>hc :Neomake ghcmod<CR>
-
-" open the neomake error window automatically when an error is found
-let g:neomake_open_list = 2
 
 " Fix path issues from vim.wikia.com/wiki/Set_working_directory_to_the_current_file
 let s:default_path = escape(&path, '\ ') " store default value of 'path'
@@ -156,8 +130,27 @@ autocmd BufRead *
 " Haskell Lint
 nmap <silent> <leader>hl :Neomake hlint<CR>
 
-" Options for Haskell Syntax Check
-let g:neomake_haskell_ghc_mod_args = '-g-Wall'
+" " GHC errors and warnings
+nnoremap <silent> <leader>hc :call GhcideCompile()<cr>
+if !exists("g:ghcide_command")
+    let g:ghcide_command = "ghcide"
+endif
+
+function! GhcideCompile()
+  " silent !clear
+  " execute "!" . g:ghcide_command . " " . bufname("%")
+  " Get the bytecode.
+  let bytecode = system(g:ghcide_command . " " . bufname("%") . " 2>&1")
+
+  " Open a new split and set it up.
+  vsplit __Ghcide_Bytecode__
+  normal! ggdG
+  setlocal filetype=potionbytecode
+  setlocal buftype=nofile
+
+  " Insert the bytecode.
+  call append(0, split(bytecode, '\v\n'))
+endfunction
 
 " }}}
 


### PR DESCRIPTION
* use [ghcide](https://github.com/digital-asset/ghcide) instead of [ghc-mod](https://github.com/DanielG/ghc-mod)
* use last LTS resolver
* don't install broken helpers

I'm not sure it is a satisfactory PR, but it it a merest attempt to renew haskell-vim-now. 